### PR TITLE
Fix typo in windmill-sync-example

### DIFF
--- a/docs/advanced/3_cli/syncing.md
+++ b/docs/advanced/3_cli/syncing.md
@@ -16,7 +16,7 @@ We provide example repos for various use cases:
 - Pushing to a remote only:
   [windmill-push-example](https://github.com/windmill-labs/windmill-push-example)
 - Syncing with a remote:
-  [windmill-backup-example](https://github.com/windmill-labs/windmill-sync-example)
+  [windmill-sync-example](https://github.com/windmill-labs/windmill-sync-example)
 
 ## Raw Syncing
 


### PR DESCRIPTION
corrected copy paste error