### PR TITLE
Update self host update instructions to warn about old images

### DIFF
--- a/docs/advanced/1_self_host/index.md
+++ b/docs/advanced/1_self_host/index.md
@@ -323,6 +323,7 @@ Database volume is persistent, so updating the database image is safe too.
 :::tip
 
 It is sufficient to run `docker compose up -d` again if your docker is already running detached, since it will pull the latest `:main` version and restart the containers.
+NOTE: The previous images are not removed automatically, you should also run `docker builder prune` to clear old versions.
 
 :::
 


### PR DESCRIPTION
I ran into an issue where I was getting "Invalid Credentials" on the frontend, as the login response was 400: `Sql error: error communicating with database: failed to lookup address information: Name or service not known`

Root cause was self hosting on a 30gb disk, running `docker compose up -d` all the time causes the docker cache to build up.

Running `docker builder prune` clears these dangling cached images which freed up ~25GB for me.