### PR TITLE
Advances: Local development: fix typos

### DIFF
--- a/docs/advanced/4_local_development/index.mdx
+++ b/docs/advanced/4_local_development/index.mdx
@@ -98,7 +98,7 @@ For more information on Deno & Bun development in general, see their official do
 ## Python
 
 Windmill python scripts can be run like normal python scripts. To add testing or
-debbug code, add this snippet to your file:
+debug code, add this snippet to your file:
 
 ```py
 if __name__ == '__main__':
@@ -226,7 +226,7 @@ For example, for TypeScript:
       "type": "pwa-node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
-      "runtimeExecutable": "deno",
+      "runtimeExecutable": "bun",
       "runtimeArgs": ["run", "${file}"],
       "env" {
         "BASE_INTERNAL_URL": "https://app.windmill.dev",


### PR DESCRIPTION
Spelling error, and a typo in the VSCode launch.json example for bun