### PR TITLE
fix typo

### DIFF
--- a/docs/core_concepts/33_codebases_and_bundles/index.mdx
+++ b/docs/core_concepts/33_codebases_and_bundles/index.mdx
@@ -2,7 +2,7 @@
 
 :::note
 
-Codebases is Beta, only work with typescript and is an enterprise feature for the time being
+Codebases is Beta, only works with typescript and is an enterprise feature for the time being
 
 :::
 


### PR DESCRIPTION
fixed typo `work` --> `works`