### PR TITLE
Add archive.org link to self-signed cert tutorial

### DIFF
--- a/docs/advanced/1_self_host/index.mdx
+++ b/docs/advanced/1_self_host/index.mdx
@@ -717,7 +717,7 @@ For more advanced setups, see [Helm Chart](#helm-chart).
 
 ## Self-signed certificates
 
-Detailed guide for using Windmill with self-signed certificates [here](https://www.lfanew.com/posts/windmill-ca-trust/).
+Detailed guide for using Windmill with self-signed certificates [here](https://www.lfanew.com/posts/windmill-ca-trust/) ([archived version](https://web.archive.org/web/20240424144202/https://www.lfanew.com/posts/windmill-ca-trust/)).
 
 TL;DR: below
 


### PR DESCRIPTION
The website the link points to seems to be gone, but I found a version on archive.org and added the link (without replacing the original).