### PR TITLE
fix(python): update python imports mapping location

### DIFF
--- a/docs/advanced/15_dependencies_in_python/index.mdx
+++ b/docs/advanced/15_dependencies_in_python/index.mdx
@@ -43,7 +43,7 @@ executed with the same versions of its dependencies. It also avoids the hassle
 of having to maintain a separate requirements file.
 
 We use a simple heuristics to infer the package name: the import root name must be the package name. We also maintain a list of exceptions.
-You can make a PR to add your dependency to the list of exceptions [here](https://github.com/windmill-labs/windmill/blob/baac93f40140ee37548a273885c028a8e6500b6d/backend/parsers/windmill-parser-py-imports/src/lib.rs#L48).
+You can make a PR to add your dependency to the list of exceptions [here](https://github.com/windmill-labs/windmill/blob/main/backend/parsers/windmill-parser-py-imports/src/mapping.rs).
 
 <div className="grid grid-cols-2 gap-6 mb-4">
 	<DocCard


### PR DESCRIPTION
Update the Python imports mapping location, changed in https://github.com/windmill-labs/windmill/commit/1a5566b8c29773d94a681c86676d4cdb0b7c7777.