### PR TITLE
Add dark mode note for CSS editor

### DIFF
--- a/docs/apps/9_css_editor.mdx
+++ b/docs/apps/9_css_editor.mdx
@@ -123,3 +123,16 @@ As a temporary solution, you can use the `!important` declaration to ensure your
   font-size: 50px !important;
 }
 ```
+## Dark mode
+
+In dark mode, Windmill adds a `dark` class to the document root. To provide alternate styling, prefix your CSS selectors with `.dark` in the CSS editor.
+
+```css
+.dark .wm-button-blue {
+  background-color: green !important;
+}
+
+.wm-button-blue {
+  background-color: red !important;
+}
+```


### PR DESCRIPTION
## Summary
- document how to override CSS rules in dark mode using the `.dark` class

## Testing
- `npm test` *(fails: Missing script)*