### PR TITLE
Fix callout block not closed properly

### DIFF
--- a/docs/advanced/11_git_sync/index.mdx
+++ b/docs/advanced/11_git_sync/index.mdx
@@ -137,7 +137,8 @@ Make sure to double check that the email address associated with the key is the 
 
 <br />
 All commits will now be signed and commited as the user matching the email address associated with the
-key. :::
+key. 
+:::
 
 #### Azure DevOps with Service Principal setup
 


### PR DESCRIPTION
Fixed the callout block. the ":::" was on the same line as text which isn't recognized causing the block to continue till the bottom of the page.

<img width="2048" height="1916" alt="image" src="https://github.com/user-attachments/assets/66984ec3-c882-47b1-9ab8-7b0655ea53a1" />
