### PR TITLE
feat: improve hero section

### DIFF
--- a/src/landing/Hero.jsx
+++ b/src/landing/Hero.jsx
@@ -32,7 +32,7 @@ export default function Hero() {
 						</div>
 						<div className="flex items-center gap-3 text-base text-gray-600 dark:text-gray-100">
 							<span className="text-blue-500 font-bold">✓</span>
-							<span>Build internal tools, workflows and data pipelines in one platform</span>
+							<span>Workflows, internal tools and data pipelines in one platform</span>
 						</div>
 						<div className="flex items-center gap-3 text-base text-gray-600 dark:text-gray-100">
 							<span className="text-blue-500 font-bold">✓</span>
@@ -40,7 +40,14 @@ export default function Hero() {
 						</div>
 						<div className="flex items-center gap-3 text-base text-gray-600 dark:text-gray-100">
 							<span className="text-blue-500 font-bold">✓</span>
-							<span>Auto-scaling infrastructure with deep built-in monitoring</span>
+							<span>Zero-ops infra powered by the{' '}
+								<Link 
+									href="/docs/misc/benchmarks/competitors"
+									className="text-white underline"
+								>
+									fastest job orchestrator and workflow engine
+								</Link>
+							</span>
 						</div>
 					</div>
 					<div className="mt-10 flex items-center gap-x-6">


### PR DESCRIPTION
- Improve subtitle and bullet points 

- Explicit problem and explicit target

- Talk less about features but more about our market positioning 

- Remove marketing buzz words "10x faster", "highest", "fastest". I understand the idea, but I suggest to emphasize on market positioning and our core differentiators to solve a problem than benchmarks. 

-> We can use benchmarks later in the landing page to illustrate, but in the hero section, I feel like the word "at scale" is enough. Otherwise if feels the same than benchmarks in AI. It's mostly buzzy. And in the end, we use a specific model because it's the best for our use case, not because it tops the benchmark. 

Overall, my main point is a hero section that focuses on market positioning, that works regardless of upcoming features in the Product, and that can be perfectly illustrated by case studies. 

Full code & internal software-> Zoom case study 
Scale -> CFA Institute 
Open source and self hosted -> Athena Intelligence & Panther Labs 


<img width="1307" height="691" alt="Capture d’écran 2025-12-17 à 17 51 53" src="https://github.com/user-attachments/assets/0af2f83d-7a42-4266-b66e-7581dcbf97f9" />
