### PR TITLE
feat: add Book a Demo modal popup

### DIFF
--- a/src/components/BookDemoModal.tsx
+++ b/src/components/BookDemoModal.tsx
@@ -1,0 +1,51 @@
+import { Dialog } from '@headlessui/react';
+import { X } from 'lucide-react';
+import React from 'react';
+
+type BookDemoModalProps = {
+	open: boolean;
+	setOpen: (open: boolean) => void;
+};
+
+export default function BookDemoModal({ open, setOpen }: BookDemoModalProps) {
+	return (
+		<Dialog open={open} onClose={() => setOpen(false)}>
+			<div className="fixed inset-0 bg-black/50 flex flex-row justify-center items-center z-50">
+				<Dialog.Panel>
+					<div className="rounded-lg bg-white dark:bg-gray-950 w-[26rem] p-6 flex flex-col gap-5">
+						<div className="flex flex-row justify-between items-start">
+							<span className="text-xl font-bold text-gray-900 dark:text-white">
+								Interested in a demo?
+							</span>
+							<button onClick={() => setOpen(false)}>
+								<X className="-m-1" />
+							</button>
+						</div>
+						<p className="text-gray-800 dark:text-gray-200">
+							Demos are designed for teams evaluating Windmill Enterprise Edition (self-hosted and cloud) or white labeling.
+						</p>
+						<p className="text-gray-800 dark:text-gray-200">
+							On a smaller team? Pro and Team plans are self-serve. Start a free trial or explore on your own.
+						</p>
+						<div className="flex flex-row gap-3">
+							<a
+								href="https://www.windmill.dev/book-demo"
+								className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-center font-medium text-white shadow-sm hover:bg-blue-800 hover:text-white !no-underline"
+								onClick={() => window.plausible?.('schedule-demo')}
+							>
+								Book a demo
+							</a>
+							<a
+								href="https://www.windmill.dev/pricing"
+								className="flex-1 rounded-md bg-gray-100 dark:bg-gray-800 px-4 py-2 text-center font-medium text-gray-900 dark:text-white shadow-sm hover:bg-gray-200 dark:hover:bg-gray-700 !no-underline"
+								onClick={() => window.plausible?.('try-cloud')}
+							>
+								Explore plans
+							</a>
+						</div>
+					</div>
+				</Dialog.Panel>
+			</div>
+		</Dialog>
+	);
+}

--- a/src/landing/CallToAction.jsx
+++ b/src/landing/CallToAction.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useColorMode } from '@docusaurus/theme-common';
+import BookDemoModal from '../components/BookDemoModal';
 
 export default function CallToAction({ color }) {
 	const { colorMode } = useColorMode();
+	const [bookDemoOpen, setBookDemoOpen] = useState(false);
 
 	const colorMap = {
 		blue: {
@@ -41,14 +43,12 @@ export default function CallToAction({ color }) {
 						>
 							Get started for free
 						</a>
-						<a
-							href="https://www.windmill.dev/book-demo"
-							data-analytics='"schedule-demo"'
-							onClick={() => window.plausible('schedule-demo')}
-							className="text-base font-semibold leading-7 text-white !no-underline dark:text-gray-900"
+						<button
+							onClick={() => setBookDemoOpen(true)}
+							className="text-base font-semibold leading-7 text-white !no-underline dark:text-gray-900 cursor-pointer bg-transparent border-none"
 						>
 							Schedule a demo <span aria-hidden="true">→</span>
-						</a>
+						</button>
 					</div>
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
@@ -79,6 +79,7 @@ export default function CallToAction({ color }) {
 					</svg>
 				</div>
 			</div>
+			<BookDemoModal open={bookDemoOpen} setOpen={setBookDemoOpen} />
 		</div>
 	);
 }

--- a/src/landing/LandingHeader.jsx
+++ b/src/landing/LandingHeader.jsx
@@ -1,5 +1,6 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { Popover, Transition } from '@headlessui/react';
+import BookDemoModal from '../components/BookDemoModal';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import classNames from 'classnames';
@@ -73,6 +74,7 @@ export default function LandingHeader() {
 	const { colorMode, setColorMode } = useColorMode();
 
 	const [hoverLogo, setHoverLogo] = React.useState(false);
+	const [bookDemoOpen, setBookDemoOpen] = useState(false);
 
 	return (
 		<div className="w-full fixed z-[1000]  bg-white dark:bg-gray-950 shadow-sm">
@@ -253,14 +255,12 @@ export default function LandingHeader() {
 							<SiDiscord className="h-5 w-5 dark:text-white text-gray-800" />
 						</a>
 
-						<a
-							href="https://www.windmill.dev/book-demo"
-							data-analytics='"schedule-demo"'
-							onClick={() => window.plausible('schedule-demo')}
-							className="hidden xl:inline-flex ml-4 items-center justify-center whitespace-nowrap rounded-md border border-transparent bg-blue-100 px-4 py-2 text-base font-medium text-blue-600 shadow-sm hover:bg-blue-200 hover:text-blue-800 !no-underline transition-all"
+						<button
+							onClick={() => setBookDemoOpen(true)}
+							className="hidden xl:inline-flex ml-4 items-center justify-center whitespace-nowrap rounded-md border border-transparent bg-blue-100 px-4 py-2 text-base font-medium text-blue-600 shadow-sm hover:bg-blue-200 hover:text-blue-800 !no-underline transition-all cursor-pointer"
 						>
 							Book a demo
-						</a>
+						</button>
 
 						<a
 							href="https://app.windmill.dev/user/login"
@@ -390,14 +390,12 @@ export default function LandingHeader() {
 								<div className="mt-6">
 									{/* Book a demo - hidden on xl screens, visible on 2xl+ */}
 									<div className="lg:block xl:hidden">
-										<a
-											href="https://www.windmill.dev/book-demo"
-											data-analytics='"schedule-demo"'
-											onClick={() => window.plausible('schedule-demo')}
-											className="!no-underline flex w-full dark:text-white items-center justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-base font-medium !text-blue-600 shadow-sm hover:bg-blue-200 hover:text-blue-800 mb-4"
+										<button
+											onClick={() => setBookDemoOpen(true)}
+											className="!no-underline flex w-full dark:text-white items-center justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-base font-medium !text-blue-600 shadow-sm hover:bg-blue-200 hover:text-blue-800 mb-4 cursor-pointer"
 										>
 											Book a demo
-										</a>
+										</button>
 									</div>
 									
 									{/* Windmill cloud - hidden on xl screens, visible on 2xl+ */}
@@ -419,6 +417,7 @@ export default function LandingHeader() {
 				</Transition>
 			</Popover>
 			{/* <Banner /> */}
+			<BookDemoModal open={bookDemoOpen} setOpen={setBookDemoOpen} />
 		</div>
 	);
 }


### PR DESCRIPTION
Replace direct demo links with a modal (explains that demos are only for Enterprise Edition and white labeling, with options to book a demo or to explore plans for smaller teams)