### PR TITLE
Add PromptWatch analytics for AI search traffic

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -166,7 +166,8 @@ const config = {
 		]
 	],
 	scripts: [
-		{ src: 'https://plausible.io/js/script.js', defer: true, 'data-domain': 'windmill.dev' }
+		{ src: 'https://plausible.io/js/script.js', defer: true, 'data-domain': 'windmill.dev' },
+		{ src: 'https://ingest.promptwatch.com/js/client.min.js', defer: true, 'data-project-id': '08b5d834-0ad7-4371-a250-26fb54b4cfba' }
 	],
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */


### PR DESCRIPTION
## Summary
- Add PromptWatch analytics script alongside existing Plausible analytics
- Tracks visitors arriving from AI search/chat platforms (ChatGPT, Claude, Perplexity, etc.)
- Cookie-less, stateless — same privacy model as Plausible

## Why
We want visibility into how much traffic comes from AI platforms citing/linking to windmill.dev, which content gets referenced most, and conversion rates from AI-referred visitors.

## What it does
- Loads `https://ingest.promptwatch.com/js/client.min.js` with `defer`
- Sends page view events (URL, referrer, locale, timezone) — no PII, no cookies
- PromptWatch segments AI-referred traffic (referrers from chatgpt.com, claude.ai, etc.)

## Test plan
- [ ] Verify docs build passes
- [ ] Confirm script loads on the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)