### PR TITLE
docs: cover missing features from recent Windmill releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,15 @@
 # Claude instructions
 
 Instructions are in @AGENTS.md
+
+## Before pushing a PR
+
+Always run `npm run build` locally before pushing. It catches broken internal
+links, broken anchors, invalid MDX, and missing files referenced from
+`sidebars.js` — all of which will block the CI `npm check` workflow.
+
+```bash
+npm run build
+```
+
+Fix any errors (and ideally any warnings in files you changed) before pushing.

--- a/blog/2025-11-12-ai-agents/index.mdx
+++ b/blog/2025-11-12-ai-agents/index.mdx
@@ -106,7 +106,7 @@ You can find the full documentation [here](/docs/core_concepts/ai_agents).
 
 **Structured output**: Conversational text is useful, but sometimes you need data in a specific format that downstream systems can consume reliably. With [JSON schema](/docs/core_concepts/ai_agents#output_schema-json-schema) validation, you can ensure the AI's response conforms to a precise structure, returning a standardized object rather than free-form text.
 
-**Image support**: AI agent steps support [images](/docs/core_concepts/ai_agents#user_images-optional) as both input and output. Provide images for the agent to analyze, or have the agent generate images in response to your request. Generated images are automatically stored in your workspace's S3-compatible [object storage](/docs/core_concepts/object_storage_in_windmill), making them immediately available for subsequent workflow steps.
+**Image support**: AI agent steps support [images](/docs/core_concepts/ai_agents#user_attachments-optional) as both input and output. Provide images for the agent to analyze, or have the agent generate images in response to your request. Generated images are automatically stored in your workspace's S3-compatible [object storage](/docs/core_concepts/object_storage_in_windmill), making them immediately available for subsequent workflow steps.
 
 ![Image output](./image_output.png "Generate images seamlessly")
 

--- a/docs/advanced/17_email_triggers/index.mdx
+++ b/docs/advanced/17_email_triggers/index.mdx
@@ -160,6 +160,33 @@ From a script or flow [deployed](../../core_concepts/0_draft_and_deploy/index.md
 
 ![Trigger panel](./trigger_panel.png "Trigger panel")
 
+### Enable/disable triggers
+
+Custom email triggers can be enabled or disabled from the trigger editor without having to delete and recreate them. Disabled triggers reject incoming emails for their address, making it easy to temporarily pause a trigger (e.g. during maintenance) and re-enable it later. Only workspace admins can toggle the enabled state.
+
+## Custom TLS certificate
+
+By default, the self-hosted SMTP server generates a self-signed TLS certificate on startup. For production deployments you can supply your own certificate so that senders can verify the server over STARTTLS.
+
+The certificate is configured via environment variables on the server container. Two modes are supported:
+
+- **Direct PEM content**: set `SMTP_TLS_CERT_PEM` and `SMTP_TLS_KEY_PKCS8_PEM` to the full PEM contents of the certificate and private key.
+- **File paths**: set `SMTP_TLS_CERT_PEM_PATH` and `SMTP_TLS_KEY_PKCS8_PEM_PATH` to paths inside the container (e.g. mounted from Kubernetes secrets or Docker volumes).
+
+The private key must be in PKCS#8 format. Convert an existing key with:
+
+```bash
+openssl pkcs8 -topk8 -nocrypt -in key.pem -out key_pkcs8.pem
+```
+
+When file paths are used, the certificate is reloaded from disk every 12 hours so that renewed certificates are picked up without restarting the server. If loading or validating the custom certificate fails, Windmill logs an error and falls back to the self-signed certificate.
+
+This feature is only available on [Enterprise Edition](/pricing).
+
+## Git sync
+
+Custom email triggers are included in [Git sync](../11_git_sync/index.mdx) alongside other event triggers (HTTP routes, WebSocket, Kafka, etc.). When the **Triggers** resource type is enabled on a git sync repository, email triggers are pushed to the repository as `*.email_trigger.yaml` files and pulled back into the workspace the same way. This lets you version, review, and promote email trigger definitions across workspaces using the regular Windmill [CLI](../3_cli/index.mdx) / git workflow.
+
 ## Error handling
 
 Email triggers support local error handlers that override workspace error handlers for specific triggers. See the [error handling documentation](../../core_concepts/10_error_handling/index.mdx#trigger-error-handlers) for configuration details and examples.

--- a/docs/advanced/18_instance_settings/index.mdx
+++ b/docs/advanced/18_instance_settings/index.mdx
@@ -307,7 +307,7 @@ Write a nuget.config file to set custom/private package sources and credentials.
 
 ### Docker registries
 
-Credentials used by `crane` when pulling private container images for [sandbox](../../core_concepts/55_sandbox/index.mdx) snapshot builds. Provide a JSON array of `{registry, username, password}` objects, for example:
+Credentials used by `crane` when pulling private container images for [sandbox](../../core_concepts/58_ai_sandbox/index.mdx) snapshot builds. Provide a JSON array of `{registry, username, password}` objects, for example:
 
 ```json
 [
@@ -486,7 +486,7 @@ Use this when AI traffic must flow through a corporate proxy or gateway that exp
 
 ### OpenTelemetry (OTEL)
 
-Enable to collect telemetry data and send it to an [OpenTelemetry](https://opentelemetry.io/) collector such as [Jaeger](https://www.jaegertracing.io/) or [Tempo](https://www.tempo.io/) for tracing. OpenTelemetry data sent to the collector consists of traces, logs, and [metrics](../../misc/9_guides/otel/index.mdx#metrics). You can independently toggle each signal (Tracing, Logs, Metrics) in the instance settings.
+Enable to collect telemetry data and send it to an [OpenTelemetry](https://opentelemetry.io/) collector such as [Jaeger](https://www.jaegertracing.io/) or [Tempo](https://www.tempo.io/) for tracing. OpenTelemetry data sent to the collector consists of traces, logs, and [metrics](../../misc/9_guides/otel/index.mdx#exporting-windmill-metrics-via-otlp). You can independently toggle each signal (Tracing, Logs, Metrics) in the instance settings.
 
 The transport protocol can also be selected from a dropdown: **grpc** (default, port 4317) or **http/protobuf** (port 4318, sets `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`). Use `http/protobuf` when your collector or network environment does not support gRPC. Follow this [guide](../../misc/9_guides/otel/index.mdx) for an example setup.
 

--- a/docs/advanced/18_instance_settings/index.mdx
+++ b/docs/advanced/18_instance_settings/index.mdx
@@ -52,6 +52,14 @@ The base URL is the public base url of the instance.
 
 If the base URL is not set correctly, some server-side generated URLs like resume URLs will be incorrect. Additionally, [OAuth and SSO](#authoauth) functionalities will not work properly.
 
+### WebSocket base url
+
+Optional override for the base URL used by the frontend to open WebSocket connections to the LSP, debugger, and multiplayer services. When empty, WebSocket connections fall back to the current `window.location` (same host as the page).
+
+Set this when the browser cannot reach WebSocket services on the same host as the main app — for example, when WebSocket services are exposed under a dedicated subdomain (e.g. `wss://ws.example.com`). The value is used as a prefix for all frontend WebSocket connections (LSP, debugger, multiplayer).
+
+A "Test connectivity" button runs HTTP health and WebSocket ping checks for the three services in parallel and reports per-service results inline.
+
 ### Email domain
 
 Domain to display in webhooks for [email triggers](../17_email_triggers/index.mdx) (should match the [MX record](https://www.cloudflare.com/learning/dns/dns-records/dns-mx-record/)).
@@ -174,6 +182,12 @@ Private Hub api secret. Only required if access to your [Private Hub is restrict
 
 This setting is only available on [Enterprise Edition](/pricing).
 
+### Disable hub
+
+When enabled, Windmill stops making any request to `hub.windmill.dev` (or your [Private Hub](../../core_concepts/32_private_hub/index.mdx)) and hides the hub pickers in the flow, app, and script editors. This is intended for closed/air-gapped deployments where outbound access to the hub is unavailable.
+
+When the hub is reachable but returns errors, the hub pickers display a persistent warning alert with a direct link back to this setting (instead of a transient error toast), guiding superadmins to toggle "Disable hub" and remove the warning.
+
 ## Auth/OAuth
 
 Windmill supports [SSO/OAuth](../../misc/2_setup_oauth/index.mdx) for user authentication. You can enable it from the Instance settings.
@@ -290,6 +304,19 @@ Provide the content of a Cargo `config.toml` file for configuring private [Rust]
 ### Nuget config
 
 Write a nuget.config file to set custom/private package sources and credentials.
+
+### Docker registries
+
+Credentials used by `crane` when pulling private container images for [sandbox](../../core_concepts/55_sandbox/index.mdx) snapshot builds. Provide a JSON array of `{registry, username, password}` objects, for example:
+
+```json
+[
+  { "registry": "ghcr.io", "username": "my-user", "password": "ghp_xxx" },
+  { "registry": "registry.example.com", "username": "ci", "password": "..." }
+]
+```
+
+Windmill writes the corresponding Docker `config.json` to `/tmp/windmill/docker` and sets `DOCKER_CONFIG` when invoking `crane export`, so private base images can be resolved without exposing credentials in the snapshot build script. This setting is fully redacted in logs.
 
 ## Alerts
 
@@ -432,13 +459,36 @@ URL to receive POST requests for instance events such as user added, OAuth signu
 
 Configure it from **Instance settings > Monitoring > Webhooks**.
 
+## AI
+
+Configure [Windmill AI](../../core_concepts/22_ai_generation/index.mdx) providers, models, and prompts once at the instance level so every workspace inherits them. Navigate to **Instance settings > AI**.
+
+Resolution order used by AI chat, code generation, and code completion:
+
+1. **Workspace AI settings** when the workspace has any provider configured.
+2. **Instance AI settings** as the fallback when the workspace has no providers configured.
+
+The fallback references resources from the `admins` workspace, so any resources used by instance AI settings must exist there. A workspace using the instance fallback shows a read-only summary of the active instance AI config and an **Override for this workspace** button; clearing the workspace override instantly reverts to instance defaults.
+
+### AI_HTTP_HEADERS
+
+Set the `AI_HTTP_HEADERS` env var on the server and workers to attach custom headers to every outgoing AI request (OpenAI, Anthropic, Azure, Bedrock, Vertex, etc.). Headers are comma-separated:
+
+```bash
+AI_HTTP_HEADERS="X-Org: acme, X-Env: prod" ./windmill
+```
+
+Use this when AI traffic must flow through a corporate proxy or gateway that expects fixed auth/routing headers. Per-resource `headers` on the `customai` resource type are applied after this env var and take precedence on conflicting keys.
+
 ## Open Telemetry & Prometheus
 
 ![Open Telemetry & Prometheus](./otel_prometheus.png)
 
 ### OpenTelemetry (OTEL)
 
-Enable to collect telemetry data and send it to an [OpenTelemetry](https://opentelemetry.io/) collector such as [Jaeger](https://www.jaegertracing.io/) or [Tempo](https://www.tempo.io/) for tracing. OpenTelementry data sent to the collector consists of traces, logs and metrics (coming soon). Follow this [guide](../../misc/9_guides/otel/index.mdx) for an example setup.
+Enable to collect telemetry data and send it to an [OpenTelemetry](https://opentelemetry.io/) collector such as [Jaeger](https://www.jaegertracing.io/) or [Tempo](https://www.tempo.io/) for tracing. OpenTelemetry data sent to the collector consists of traces, logs, and [metrics](../../misc/9_guides/otel/index.mdx#metrics). You can independently toggle each signal (Tracing, Logs, Metrics) in the instance settings.
+
+The transport protocol can also be selected from a dropdown: **grpc** (default, port 4317) or **http/protobuf** (port 4318, sets `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`). Use `http/protobuf` when your collector or network environment does not support gRPC. Follow this [guide](../../misc/9_guides/otel/index.mdx) for an example setup.
 
 ### HTTP tracing
 
@@ -466,6 +516,12 @@ Expose [Prometheus](https://prometheus.io/) metrics for workers and servers on p
 ## Indexer 
 
 ![Indexer](./indexer.png)
+
+### Max index time window
+
+Maximum time window (in days) that the indexer looks back when indexing jobs and service logs. Defaults to 7 days. This caps both the initial population of the index and periodic cleanup — documents older than the window are not indexed and are evicted on the next refresh cycle. Windmill internally uses `min(max_index_time_window_secs, retention_period_secs)` so the window never exceeds the configured [retention period](#retention-period-in-secs). Setting the value to 0 disables the time window and falls back to the retention period alone.
+
+This setting can also be controlled via the `TANTIVY_MAX_INDEX_TIME_WINDOW__S` env var.
 
 ### Index writer memory budget 
 

--- a/docs/advanced/3_cli/dev-preview.md
+++ b/docs/advanced/3_cli/dev-preview.md
@@ -8,7 +8,7 @@ The CLI can run scripts and flows against a remote workspace without deploying t
 
 ## `wmill script preview`
 
-Preview a local script file against the remote workspace. Supports both regular scripts and [codebase](../../core_concepts/42_code_sharing/index.md) scripts (which are bundled before running).
+Preview a local script file against the remote workspace. Supports both regular scripts and [codebase](../../core_concepts/33_codebases_and_bundles/index.mdx) scripts (which are bundled before running).
 
 ```bash
 wmill script preview <path> [options]

--- a/docs/advanced/3_cli/dev-preview.md
+++ b/docs/advanced/3_cli/dev-preview.md
@@ -1,0 +1,63 @@
+---
+description: How do I preview scripts and flows locally using the Windmill CLI?
+---
+
+# Dev & Preview
+
+The CLI can run scripts and flows against a remote workspace without deploying them, which is useful for iterating on local files, validating codebase scripts, or testing flow changes with local inline script modifications.
+
+## `wmill script preview`
+
+Preview a local script file against the remote workspace. Supports both regular scripts and [codebase](../../core_concepts/42_code_sharing/index.md) scripts (which are bundled before running).
+
+```bash
+wmill script preview <path> [options]
+```
+
+### Options
+
+| Option             | Description                                                       |
+| ------------------ | ----------------------------------------------------------------- |
+| `-d, --data <data>`| Inputs as a JSON string, `@filename`, or `@-` for stdin.          |
+| `-s, --silent`     | Only output the final result (no logs, useful for scripting).     |
+
+### Examples
+
+```bash
+# Regular script
+wmill script preview u/admin/my_script.ts --data '{"x": 5}'
+
+# Codebase script (bundled before preview)
+wmill script preview f/codebase_test/my_script.ts --data '{"x": 7}'
+
+# Silent mode for piping
+wmill script preview f/scripts/hello.ts -d '{"n":3}' --silent | jq
+```
+
+## `wmill flow preview`
+
+Preview a local flow against the remote workspace. The flow definition is read from the local `.flow` / `__flow` folder — any changes to inline scripts are picked up without deploying.
+
+```bash
+wmill flow preview <path> [options]
+```
+
+### Options
+
+Same `-d, --data` and `-s, --silent` options as `script preview`.
+
+### Example
+
+```bash
+wmill flow preview f/my_flows/etl__flow --data '{"date":"2026-01-01"}'
+```
+
+## `wmill flow dev`
+
+`wmill flow dev` starts a local dev loop for a flow: it watches the flow's local files, and on each change pushes the flow so you can test it interactively from the Windmill UI with fast feedback.
+
+```bash
+wmill flow dev <path>
+```
+
+Run `wmill flow dev --help` to see the full set of flags. Use this when iterating on flow YAML / inline scripts and testing via the UI; use `wmill flow preview` when you want a one-shot run with a specific payload.

--- a/docs/advanced/3_cli/folder.md
+++ b/docs/advanced/3_cli/folder.md
@@ -26,3 +26,39 @@ wmill folder push <folder_path:string> <remote_path:string>
 | ------------- | ---------------------------------------------------------------- |
 | `folder_path` | The path to the local folder.                                    |
 | `remote_path` | The path to the remote location where the folder will be pushed. |
+
+## Adding missing folders
+
+When you create scripts, flows, or apps under `f/<folder>/` without a corresponding `f/<folder>/folder.meta.yaml` file, `wmill sync push` will either warn (admins) or fail (non-admins, due to RLS) because the remote folder does not exist.
+
+The `wmill folder add-missing` command scans every `f/<folder>/` subdirectory and creates a default `folder.meta.yaml` for any that are missing one.
+
+```bash
+wmill folder add-missing [-y]
+```
+
+### Options
+
+| Option | Description                        |
+| ------ | ---------------------------------- |
+| `-y`   | Skip the confirmation prompt.      |
+
+### Example
+
+```bash
+# Dry scan, then create the missing files after confirmation
+wmill folder add-missing
+
+# Non-interactive (useful in scripts)
+wmill folder add-missing -y
+```
+
+`wmill sync push` runs the same detection automatically and suggests `wmill folder add-missing` when folders are missing.
+
+## Stale script detection
+
+`wmill generate-metadata` builds a dependency tree across scripts, flows, apps, and [workspace dependencies](../../core_concepts/55_workspace_dependencies/index.mdx), then propagates staleness along that graph. This means if script `C` changes, any scripts `A` and `B` that transitively import `C` (including via relative imports like `./helper` or `../shared/utils`) are correctly detected as stale and regenerated.
+
+When you run `wmill generate-metadata f/lib`, scripts **outside** `f/lib` that import from it are included in the run by default. Use `--strict-folder-boundaries` to restrict the run to items physically inside the folder — excluded items that would otherwise have been regenerated are printed as warnings.
+
+See [`wmill generate-metadata`](./generate-metadata.md) for the full option list.

--- a/docs/advanced/3_cli/index.mdx
+++ b/docs/advanced/3_cli/index.mdx
@@ -39,3 +39,38 @@ See [Installation](./installation.md) for getting started.
 		href="/docs/advanced/local_development"
 	/>
 </div>
+
+## Unified `list` / `get` / `new` subcommands
+
+Every item type supports the same set of subcommands so the CLI can be used as a full API client in shell scripts — piping JSON output to `jq`, etc.
+
+| Subcommand | Behavior |
+| ---------- | -------- |
+| `<type> list [--json]` | Lists items. With `--json`, outputs machine-readable JSON. |
+| `<type> get <path> [--json]` | Pretty-prints an item. With `--json`, outputs the full API response. |
+| `<type> new <path> [...]` | Bootstraps a local template file for the item. `bootstrap` remains as an alias for script/flow. |
+
+The supported types are: `script`, `flow`, `app`, `resource`, `resource-type`, `variable`, `schedule`, `folder`, and `trigger`. For `trigger`, pass `--kind <type>` (e.g. `http`, `websocket`, `kafka`, ...) to `new` and to `get` when multiple trigger kinds share a path.
+
+```bash
+wmill script list --json | jq '.[].path'
+wmill trigger new f/http/webhook --kind http
+wmill resource get f/db/prod --json | jq .value.host
+```
+
+## `wmill docs`
+
+The `wmill docs` command searches the Windmill documentation from your terminal. It calls the backend search endpoint and prints formatted results.
+
+```bash
+wmill docs <query> [--json]
+```
+
+### Example
+
+```bash
+wmill docs "how do I create a flow?"
+wmill docs "what are resources?" --json | jq .answer
+```
+
+Documentation search is an Enterprise Edition feature — on a Community Edition instance, the command prints a message indicating EE is required.

--- a/docs/advanced/3_cli/lint.md
+++ b/docs/advanced/3_cli/lint.md
@@ -1,0 +1,70 @@
+---
+description: How do I lint and validate Windmill YAML files using the Windmill CLI?
+---
+
+# Lint
+
+The `wmill lint` command validates Windmill YAML files (flows, schedules, and triggers) against their schemas. It scans a directory tree, infers each file's type from its filename (`.flow.yaml`, `.schedule.yaml`, `.http_trigger.yaml`, etc.), and reports missing required fields, unknown properties, or invalid values.
+
+## Usage
+
+```bash
+wmill lint [directory] [options]
+```
+
+If no directory is provided, the current directory is used. The command respects the `includes`/`excludes` patterns from your `wmill.yaml`.
+
+## Options
+
+| Option              | Description                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------ |
+| `--json`            | Output machine-readable JSON instead of formatted text.                                          |
+| `--fail-on-warn`    | Exit non-zero on warnings (e.g. skipped native triggers).                                        |
+| `--locks-required`  | Fail if any script or inline script that needs a lock is missing one.                            |
+
+Native triggers (triggers whose schema depends on a dynamic `service_config`) are skipped with a warning — no static schema is available for them.
+
+## Examples
+
+Lint every YAML file under the current directory:
+
+```bash
+wmill lint
+```
+
+Lint a specific folder and emit JSON for CI tooling:
+
+```bash
+wmill lint f/my_project --json
+```
+
+Fail the build if any script/flow/app inline script is missing its lockfile:
+
+```bash
+wmill lint --locks-required
+```
+
+## `--locks-required`
+
+`--locks-required` checks standalone scripts, flow inline scripts, normal app inline scripts, and raw app backend scripts. It applies to languages that need a lock: `bun`, `python3`, `php`, `go`, `deno`, `rust`, and `ansible`.
+
+The flag can also be enabled globally in `wmill.yaml`:
+
+```yaml
+locksRequired: true
+```
+
+When set, `wmill sync push` runs the same verification before pushing, failing fast if anything is missing.
+
+## CI integration
+
+A typical GitHub Actions step:
+
+```yaml
+- name: Validate Windmill YAML files
+  run: |
+    npm install -g windmill-cli
+    wmill lint --fail-on-warn --locks-required
+```
+
+Pair `wmill lint` with [`wmill generate-metadata`](./generate-metadata.md) to (re)generate any missing lockfiles before linting.

--- a/docs/advanced/3_cli/sync.mdx
+++ b/docs/advanced/3_cli/sync.mdx
@@ -153,6 +153,30 @@ wmill sync push [options]
 
 Note that you can set the default TypeScript language and explicitly exclude (or include) specific files or folders to be taken into account with a [`wmill.yaml` file](https://github.com/windmill-labs/windmill-sync-example/blob/main/wmill.yaml).
 
+### Generating and inspecting the config
+
+`wmill init` generates a fully commented `wmill.yaml` with every option documented inline and grouped by category. Advanced / opt-in options are included as commented-out examples, so you can discover and enable them without having to look them up.
+
+`wmill config` prints a structured reference table of all config options with their types, defaults, and descriptions. Pair it with `--json` for programmatic consumption (for example, from an AI agent that edits `wmill.yaml`).
+
+```bash
+wmill config            # human-readable reference
+wmill config --json     # JSON reference, one entry per option
+```
+
+A JSON Schema is also committed at [`cli/wmill.schema.json`](https://github.com/windmill-labs/windmill/blob/main/cli/wmill.schema.json) for editor autocomplete and validation of your `wmill.yaml`.
+
+### Non-dotted paths (`nonDottedPaths`)
+
+By default, local files for flows, apps, and raw apps are stored under folders named `<path>__flow/`, `<path>__app/`, and `<path>__raw_app/` (using `__flow`/`__app`/`__raw_app` suffixes rather than dotted extensions). This avoids filesystem edge-cases on Windows and with tooling that assumes a `.flow` extension means a file.
+
+```yaml
+# wmill.yaml
+nonDottedPaths: true   # default for new workspaces created with `wmill init --use-default`
+```
+
+Set `nonDottedPaths: false` to fall back to legacy `.flow`/`.app`/`.raw_app` folder names.
+
 ### Basic configuration
 
 ```yaml

--- a/docs/advanced/3_cli/user.md
+++ b/docs/advanced/3_cli/user.md
@@ -89,3 +89,76 @@ There are two ways to create a token:
   The command will use your existing authentication credentials to create a token and display it.
 
 The command will display the generated token, which can be used for subsequent authenticated requests. Note that the token is not stored locally.
+
+## Groups
+
+The `wmill group` commands manage [workspace groups](../../core_concepts/8_groups_and_folders/index.mdx) and their members.
+
+```bash
+wmill group list
+wmill group get <name>
+wmill group create <name> [--summary <summary>]
+wmill group delete <name>
+wmill group add-user <group> <username>
+wmill group remove-user <group> <username>
+```
+
+### Examples
+
+```bash
+# List all groups and create a new one
+wmill group list
+wmill group create data-team --summary "Data engineering"
+
+# Manage membership
+wmill group add-user data-team alice
+wmill group remove-user data-team bob
+```
+
+## Audit logs
+
+The `wmill audit` commands read from the workspace [audit log](../../core_concepts/42_audit_logs/index.mdx) (Enterprise Edition).
+
+```bash
+wmill audit list [options]
+wmill audit get <id>
+```
+
+### Options
+
+| Option            | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `--username`      | Filter by username.                                      |
+| `--operation`     | Filter by operation (e.g. `scripts.create`).             |
+| `--action-kind`   | Filter by action kind (`create`, `update`, `delete`, `execute`). |
+| `--before`        | Return entries before this timestamp.                    |
+| `--after`         | Return entries after this timestamp.                     |
+
+### Examples
+
+```bash
+# Recent activity by a user
+wmill audit list --username alice --after 2026-01-01
+
+# Inspect a single event
+wmill audit get 1234
+```
+
+## Tokens
+
+The `wmill token` commands manage API tokens for the current user.
+
+```bash
+wmill token list
+wmill token create [--label <label>] [--expires-in <seconds>]
+wmill token delete <token>
+```
+
+### Example
+
+```bash
+# Create a token valid for a CI job, then delete it after use
+TOKEN=$(wmill token create --label ci --expires-in 3600)
+...
+wmill token delete "$TOKEN"
+```

--- a/docs/advanced/3_cli/user.md
+++ b/docs/advanced/3_cli/user.md
@@ -117,7 +117,7 @@ wmill group remove-user data-team bob
 
 ## Audit logs
 
-The `wmill audit` commands read from the workspace [audit log](../../core_concepts/42_audit_logs/index.mdx) (Enterprise Edition).
+The `wmill audit` commands read from the workspace [audit log](../../core_concepts/14_audit_logs/index.mdx) (Enterprise Edition).
 
 ```bash
 wmill audit list [options]

--- a/docs/advanced/3_cli/workspace-management.md
+++ b/docs/advanced/3_cli/workspace-management.md
@@ -8,13 +8,21 @@ Windmill CLI can be used on several workspaces from several instances.
 
 ## List workspaces
 
-You can list all the workspaces you have access to using:
+You can list all the workspaces registered locally on your machine with:
 
 ```bash
 wmill workspace
 ```
 
 The currently selected workspace will be <ins>underlined</ins>.
+
+### Listing remote workspaces
+
+`wmill workspace list` queries the currently selected remote server and shows every workspace the authenticated user has access to — regardless of whether each workspace is registered locally. This is useful to discover workspaces you could add with `wmill workspace add`.
+
+```bash
+wmill workspace list
+```
 
 ## Adding a workspace
 
@@ -157,3 +165,20 @@ The workspace encryption key is migrated along with the workspace. During the [p
 When [synchronizing workspaces](./sync.mdx), the `--include-key` option should be used to ensure the encryption key is also included in the sync process. This is essential for maintaining the security and integrity of encrypted data as it moves between environments.
 
 This option prompts you to confirm if the encryption key should be replaced or retained. Make an informed choice based on whether the destination environment requires a new key or should continue using the existing key.
+
+## Schedule enable/disable
+
+The `wmill schedule enable` and `wmill schedule disable` commands are a quick way to toggle a schedule on or off without editing the corresponding YAML file and running `wmill sync push`.
+
+```bash
+wmill schedule enable <path>
+wmill schedule disable <path>
+```
+
+### Example
+
+```bash
+# Pause a nightly job during a maintenance window, then re-enable it
+wmill schedule disable f/reports/nightly_etl
+wmill schedule enable f/reports/nightly_etl
+```

--- a/docs/core_concepts/11_persistent_storage/data_tables.mdx
+++ b/docs/core_concepts/11_persistent_storage/data_tables.mdx
@@ -12,6 +12,8 @@ This page is part of our section on [Persistent storage & databases](./index.mdx
 
 Windmill **Data Tables** let you store and query relational data with **near-zero setup** using databases managed automatically by Windmill. They provide a simple, safe, workspace-scoped way to leverage SQL inside your workflows without exposing credentials. Data tables can also be used from [full-code apps](../../full_code_apps/4_data_tables/index.mdx) via SQL backend runnables and from the [Database Studio](../../apps/4_app_configuration_settings/database_studio.mdx) app component for browsing and editing data visually.
 
+Data tables are queryable as a **typed** schema from TypeScript, Python and DuckDB clients, and can be browsed, edited and used as a Postgres trigger source without ever exposing the underlying connection string to users.
+
 ---
 
 ## Getting started
@@ -89,6 +91,22 @@ sql = wmill.datatable(':myschema'); // or 'named_datatable:myschema'
 sql`SELECT * FROM mytable`; // refers to myschema.mytable
 ```
 
+### Schemas
+
+Data tables support Postgres schemas to organize tables into logical groupings within a single data table. You can:
+
+- Create, rename and drop schemas from the workspace settings Data Tables UI.
+- Reference tables with the explicit `schema.table` syntax, or switch the default search path from the client by appending `:myschema` after the data table name (`wmill.datatable('named_datatable:myschema')` or `wmill.datatable(':myschema')` for the default data table).
+- Use schemas as an organizational boundary without needing multiple data tables — we recommend keeping the number of data tables per workspace small and using schemas for separation.
+
+### Type-checked queries
+
+The Windmill editor understands your data table's schema and **type-checks queries at edit time** for TypeScript, Python and DuckDB scripts. The introspected schema (tables, columns, types) is surfaced in the editor's SQL IntelliSense, and invalid columns or type mismatches are flagged before the script ever runs.
+
+String-interpolated parameters (e.g. `` sql`SELECT * FROM friend WHERE id = ${user_id}` ``) are always transformed into safe parameterized queries, so type checking covers both the SQL itself and the bindings.
+
+When a data table schema changes, the editor re-introspects it so downstream scripts immediately see the new columns and types without a manual refresh.
+
 ### Assets integration
 
 Data tables are **assets** in Windmill.
@@ -101,6 +119,16 @@ Windmill auto detects if the data table was used in Read (SELECT ... FROM) or Wr
 Assets are displayed as asset nodes in flows, making it easy to visualize data dependencies between scripts.
 
 ![Data Table asset flow](./datatable_images/datatable_asset_flow.png 'Data Table asset flow')
+
+### Database Studio integration
+
+Data tables are a first-class source in the [Database Studio](../../apps/4_app_configuration_settings/database_studio.mdx) app component. Select **Data Table** as the component's `Type`, then use the built-in table picker to choose from the workspace's configured data tables — no resource wiring required.
+
+From there you get the full Database Studio experience (browse rows, inline edit, create/alter tables, schema explorer) on top of your data tables, without exposing the underlying credentials to the app builder or end users.
+
+### Use as a Postgres resource and trigger source
+
+A data table that is backed by a Postgres resource (either the custom instance database or a workspace-managed Postgres resource) can be used anywhere a Postgres resource is expected — most notably as the source of a [Postgres trigger](../46_postgres_triggers/index.mdx). This lets you react to inserts, updates and deletes on tables managed by a data table without handing out the Postgres credentials.
 
 ---
 
@@ -148,3 +176,7 @@ Currently, Windmill does **not** enforce database-level permissions in data tabl
 - Table/row-level permissions may be introduced in a later version.
 
 Windmill ensures secure access by handling database credentials internally.
+
+## Use on agent workers
+
+`wmill.datatable()` and `wmill.ducklake()` work on [agent workers](../28_agent_workers/index.mdx) out of the box, from both TypeScript and Python. Because agent workers do not run the embedded internal Windmill server, the clients automatically detect the execution environment and fall back from the inline preview path to a run-and-wait flow against the main Windmill API, so scripts that use data tables remain portable between regular and agent workers with no code changes.

--- a/docs/core_concepts/22_ai_generation/index.mdx
+++ b/docs/core_concepts/22_ai_generation/index.mdx
@@ -256,8 +256,78 @@ Windmill AI supports:
 - OpenRouter's [models](https://openrouter.ai/models)
 - Together AI's [models](https://docs.together.ai/docs/serverless-models)
 - AWS Bedrock's [models](https://aws.amazon.com/bedrock/)
-  - Required configuration: AWS region and long term API key
 - Custom AI: base URL and API key of any AI provider that is OpenAI API-compatible
   - For Ollama and other local models, select "Custom AI" and provide your Ollama server URL (e.g., `http://localhost:11434/v1` for local Ollama or your custom endpoint)
 
 If you'd like to use a model that isn't in the default dropdown list, you can use any model supported by a provider (like `gpt-4o-2024-05-13` or `claude-3-7-sonnet-20250219`) by simply typing the model name in the model input field and pressing enter.
+
+### Provider-specific configuration
+
+Some providers accept additional fields on their [resource](../3_resources_and_types/index.mdx) beyond the base URL and API key.
+
+#### AWS Bedrock
+
+Bedrock accepts any of three authentication modes on the resource — the worker picks the first one that is fully provided:
+
+1. **Long-term IAM user keys**: set `awsAccessKeyId` and `awsSecretAccessKey`, plus an optional `awsSessionToken` when you are using temporary credentials (e.g. from AWS STS).
+2. **Bedrock bearer API key**: set the resource's `apiKey` to an [Amazon Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html). This takes precedence over the IAM key pair when both are set.
+3. **Ambient IAM role**: leave `apiKey` and the access keys empty. The worker falls back to the default AWS credential chain (IRSA / EKS Pod Identity / EC2 instance profile / `AWS_*` environment variables) resolved against the configured `region`.
+
+The `region` field is required in all cases. Bedrock requests use the AWS SDK's native Converse API, so models are referenced by their native Bedrock model id (e.g. `anthropic.claude-3-5-sonnet-20241022-v2:0`).
+
+#### Anthropic
+
+- **1M context window**: enable the `enable_1m_context` toggle on an Anthropic resource to send the `anthropic-beta: context-1m-2025-08-07` header with every request. This unlocks the 1M-token context window on compatible Claude models. The flag is ignored when the Anthropic resource is routed through Google Vertex AI.
+
+#### Google Gemini / Anthropic on Vertex AI
+
+Both the `googleai` and `anthropic` resources expose a `platform` field that switches between the provider's standard API and Google Vertex AI:
+
+- `platform: standard` (default) — the provider's public API.
+- `platform: google_vertex_ai` — route requests through Vertex AI. Set `base_url` to your Vertex endpoint and `api_key` to an OAuth2 access token for a Google Cloud service account with the `Vertex AI User` role.
+  - Gemini example: `https://{region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{region}/publishers/google/models`
+  - Claude-on-Vertex example: `https://{region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{region}/publishers/anthropic/models`
+
+`base_url` overrides are also honored on the standard platform, which is useful for pointing an Anthropic or Gemini resource at an internal proxy.
+
+#### Custom AI (`customai`)
+
+In addition to `base_url` and `api_key`, the `customai` resource accepts a `headers` object mapping header names to values. Those headers are attached to every AI request made with that resource, which is handy for upstream proxies, gateway auth, or routing metadata.
+
+```json
+{
+  "base_url": "https://my-gateway.example.com/v1",
+  "api_key": "sk-...",
+  "headers": {
+    "X-Tenant-Id": "team-42",
+    "X-Route": "prod"
+  }
+}
+```
+
+Resource-level `headers` are applied after the instance-wide `AI_HTTP_HEADERS` env var, so they take precedence on conflicting keys.
+
+### Instance-wide AI HTTP headers
+
+Set the `AI_HTTP_HEADERS` environment variable on the server and workers to attach custom headers to every outgoing AI request (OpenAI, Anthropic, Azure, Bedrock, etc.). Headers are comma-separated:
+
+```bash
+AI_HTTP_HEADERS="X-Org: acme, X-Env: prod" ./windmill
+```
+
+This is the right knob when every AI request in the instance must traverse a corporate proxy or gateway that expects fixed auth/routing headers.
+
+## Instance-level AI settings
+
+Superadmins can configure AI providers, models, and prompts once at the instance level and have every workspace inherit them. Navigate to **Instance settings → AI** to set it up.
+
+Resolution order for the AI config used by chat, code generation, and code completion:
+
+1. **Workspace AI settings** when the workspace has any provider configured — these always win.
+2. **Instance AI settings** as the fallback when the workspace has no providers configured.
+
+The fallback resources are read from the `admins` workspace, so any resources referenced by instance AI settings must exist there.
+
+In a workspace that is using the instance fallback, the Windmill AI settings page shows a read-only "Active instance AI" summary and an **Override for this workspace** button to reveal the editable workspace form. Clearing the workspace providers reverts the workspace to the instance fallback immediately, without a page refresh.
+
+Non-admin members can use AI chat whenever either scope is configured — they do not need access to workspace or instance settings.

--- a/docs/core_concepts/2_variables_and_secrets/index.mdx
+++ b/docs/core_concepts/2_variables_and_secrets/index.mdx
@@ -117,6 +117,77 @@ A variable can be made secret. In this case, its value will not be visible outsi
 
 ![Add variable](./add_variable.png.webp)
 
+## Secret masking in job logs
+
+Windmill automatically masks secret values in job logs to prevent accidental leakage. When a job fetches a secret variable (or is given `$encrypted:` arguments), the plaintext values are tracked per-job and masked in stdout/stderr before logs are persisted.
+
+When a masked value would appear in the logs, the first 3 characters are kept for debuggability and the rest is replaced by `*****`, followed by a one-time notice line:
+
+```
+my_*****
+[windmill] secret value was masked for security reasons, use string transformations to display partial values
+```
+
+Notes:
+- Only values of 8 characters or more are masked, to avoid false positives on short strings like `"true"` or `"1234"`.
+- Only the values of **secret variables** and decrypted `$encrypted:` arguments are tracked — non-secret variables remain fully visible.
+- Masking happens in-memory before the logs are written to the database, so plaintext secrets never land in `job_logs`.
+- If your script needs to display a partial secret (e.g. the last 4 characters of a token), use string transformations inside the script before logging, since the full match will always be masked.
+
+## Secret storage backends <span className="text-red-500">EE</span>
+
+By default, Windmill stores encrypted secrets in its own database using a workspace-specific symmetric key. On [Enterprise Edition](/pricing), superadmins can instead delegate secret storage to an external secret manager, keeping the ciphertext out of the Windmill database entirely.
+
+Secret backends are configured instance-wide from **Instance Settings → Secret backend**. Changes take effect immediately without restarting the server, and Windmill provides a **Test connection** button plus bidirectional migration endpoints to move existing secrets between backends (`Database → Vault/Key Vault` and back).
+
+**Fail-closed by design:** if the configured backend is unreachable, secret reads and writes fail rather than silently falling back to the database.
+
+### HashiCorp Vault backend
+
+Windmill can store secrets natively in [HashiCorp Vault](https://www.vaultproject.io/) using the KV v2 secrets engine.
+
+Configuration requires:
+
+- The Vault server URL and namespace (if applicable).
+- A KV v2 mount path where Windmill will read and write secrets.
+- A JWT auth role configured in Vault. Windmill exposes a JWKS endpoint at `/.well-known/jwks.json` that Vault uses to validate the short-lived JWTs Windmill issues on every secret operation.
+
+Once configured:
+- All new and updated secret variables are written to Vault.
+- Existing database-backed secrets can be migrated with the **Migrate secrets to Vault** action in Instance Settings.
+- The reverse migration (**Migrate secrets to Database**) is also available to roll back.
+
+### Azure Key Vault backend
+
+Windmill can also store secrets in [Azure Key Vault](https://azure.microsoft.com/en-us/products/key-vault). Configuration requires the Key Vault URL and service principal credentials (tenant ID, client ID, client secret) with the necessary `Get`/`Set`/`Delete` permissions on the vault.
+
+The migration and fail-closed semantics are identical to the Vault backend.
+
+## Sensitive and secret inputs
+
+Resource, script and flow inputs can also be marked as sensitive so that their values are treated as secrets at submission time — not only when stored long-term.
+
+### Password/sensitive string fields
+
+Any string field on a resource, script parameter or flow input can be flagged as **Password / Sensitive** in the schema editor. The field renders as a masked input in the auto-generated form and an eye icon lets users toggle visibility.
+
+**Multiline secrets** (SSH private keys, PEM certificates, multi-line tokens) are supported: the field starts as a single-line password input and automatically switches to a masked textarea when multiline content is detected (pasted content with newlines, Enter pressed inside the field, or values already containing newlines). You can also force the textarea mode from the start by setting **Min textarea rows** > 1 in the schema editor.
+
+### Sensitive fields on non-string types
+
+Object fields in script UI customization and flow inputs can also be marked **Is sensitive**. On submit, the value is stored as an ephemeral secret variable and replaced in the args with a `$jsonvar:<path>` reference. At job execution, Windmill fetches the variable and JSON-parses the value so the script still receives the original object — identical to how `$var:` works for string secrets, but for arbitrary JSON payloads.
+
+`$jsonvar:` references are also clickable in the job args viewer for users with access.
+
+### Multiple secret fields per resource
+
+When creating a resource, you can mark **multiple fields** as secret (e.g. both `api_key` and `refresh_token` on the same resource). Windmill creates one secret variable per sensitive field:
+
+- If a single field is marked secret, a single variable is created at the resource path (unchanged behavior).
+- If multiple fields are marked secret, each gets its own variable with `_<field_name>` appended to the resource path.
+
+This makes it easy to rotate individual credentials without touching the others, and keeps each sensitive value auditable on its own.
+
 ## Accessing a variable from a script
 
 <div className="grid grid-cols-2 gap-6 mb-4">

--- a/docs/core_concepts/38_object_storage_in_windmill/index.mdx
+++ b/docs/core_concepts/38_object_storage_in_windmill/index.mdx
@@ -420,6 +420,25 @@ This allows the handling of large-scale logs with minimal database impact, suppo
 
 For large logs storage (and display) and cache for distributed Python jobs, you can [connect your instance to a bucket](../20_jobs/index.mdx#large-job-logs-management). This feature is at the Instance-level, and has no overlap with the Workspace object storage.
 
+When instance object storage is configured from the UI, the **Monitor logs on S3** toggle (`monitor_logs_on_s3`) defaults to **on** — meaning Windmill mirrors service logs and job log chunks to the configured bucket for long-term storage and search. You can explicitly disable it if you prefer to keep logs on disk/DB only.
+
+### Storage usage by folder
+
+The Object Storage panel in **Instance settings** includes a **Storage usage by folder** view. Click **Show usage** (or **Refresh**) to list the top-level prefixes of your instance bucket with their total size, sorted largest first. Root-level files are aggregated under `(root files)`. This is a superadmin-only tool and is gated on the `parquet` build feature.
+
+The listing operation has a 30s timeout and is safe to run on production buckets — it only enumerates objects, it does not mutate anything.
+
+### Manual log cleanup
+
+Below the usage panel, **Clean up expired logs** triggers the same cleanup logic normally run by the cron job, on demand:
+
+- Deletes expired **service log** rows (and their associated log files on disk and in S3) in batches of 2000.
+- Deletes expired **job log** rows using the same transactional `SKIP LOCKED` semantics as the background monitor, then batches the S3 deletes (up to 1000 objects per `DeleteObjects` request) for a ~1000x speedup over per-object deletes.
+
+The panel shows a live progress bar, per-phase counters, the number of S3 objects deleted, errors, and the last-run timestamp. Polling runs every second and resumes automatically if you reload the page while a cleanup is in progress. Only one cleanup can run at a time (a second request returns `400 already running`).
+
+Manual cleanup always deletes from S3, even if `MONITOR_LOGS_ON_OBJECT_STORE` is currently off, so you can use it to reclaim orphaned objects from a previous configuration.
+
 ### Instance object storage distributed cache for Python, Rust, Go
 
 [Workers](../../core_concepts/9_worker_groups/index.mdx) cache aggressively the [dependencies](../../advanced/6_imports/index.mdx) (and each version of them since every script has its own lockfile with a specific version for each dependency) so they are never pulled nor installed twice on the same worker. However, with a bigger cluster, for each script, the likelihood of being seen by a worker for the first time increases (and the cache hit ratio decreases).

--- a/docs/core_concepts/39_http_routing/index.mdx
+++ b/docs/core_concepts/39_http_routing/index.mdx
@@ -82,6 +82,14 @@ You can use `:param` in the route path and access these as `params` in a [prepro
 
 ---
 
+### Enable/disable
+
+Each HTTP route has an **enabled** toggle that can be flipped without deleting the trigger. Disabled routes stop matching incoming requests and return `404` until re-enabled, which is useful when temporarily taking an endpoint offline for maintenance, cutting over between versions, or pausing a route that is misbehaving without losing its configuration.
+
+The toggle is available from the route editor and the HTTP routes list page. Only users with write access to the trigger can change its enabled state.
+
+---
+
 ### Workspace prefix
 
 On Windmill Cloud, all HTTP routes are automatically prefixed by the `workspace_id` (e.g., `{workspace_id}/{path}`).  
@@ -100,6 +108,16 @@ When workspace prefix is disabled (on self-hosted):
 **Example:**  
 If workspace A creates the route `/webhooks/github`, then without workspace prefix, no other workspace can create `/webhooks/github`.  
 With workspace prefix enabled, workspace A could have `/workspace_a/webhooks/github` and workspace B could have `/workspace_b/webhooks/github`.
+
+#### Enforcing the workspace prefix instance-wide
+
+On self-hosted instances, superadmins can enforce the workspace prefix for every HTTP route via the **HTTP route workspace prefix** instance setting (under `/#superadmin-settings`). When enabled:
+
+- New and existing routes are served under `/api/r/{workspace_id}/{route}` regardless of the per-route toggle.
+- The per-route workspace-prefix toggle in the route editor is disabled and labeled as enforced by the instance setting.
+- The setting can only be turned off again if no two workspaces share the same route path; otherwise a collision error is returned.
+
+This mirrors the equivalent `app_workspaced_route` setting for apps and is the recommended default for multi-tenant self-hosted instances.
 
 ---
 
@@ -254,6 +272,16 @@ Windmill supports several ways to secure HTTP triggers:
 
 ---
 
+### Token scopes
+
+When **Windmill Auth** is selected, the JWT token used to call the route must carry an `http_triggers:read` scope for the route path. A fully-scoped user token calling a route at `my/route` needs the scope `http_triggers:read:my/route`.
+
+From the route configuration page, Windmill can generate a token pre-scoped to exactly this route: in the **Windmill Auth** section click **Generate token**, and a new token limited to `http_triggers:read:<route_path>` is created. That token can safely be shared with the caller because it can only read (i.e., trigger) this specific HTTP route and cannot impersonate the issuing user for any other operation.
+
+See [User tokens](../59_user_tokens/index.mdx#token-scopes) for the full scope format and the list of available domains.
+
+---
+
 ### Signature Auth (HMAC-based)
 
 Use **Signature Auth** to validate incoming HTTP requests using HMAC-style signatures.
@@ -285,6 +313,35 @@ export async function main(body: unknown) {
 export async function main(raw_string: string) {
   console.log("Raw body received:", raw_string);
   return JSON.parse(raw_string);
+}
+```
+
+---
+
+## CORS headers
+
+HTTP route responses include permissive CORS headers by default so that routes can be called directly from browser clients:
+
+| Header | Default value |
+| --- | --- |
+| `Access-Control-Allow-Origin` | `*` |
+| `Access-Control-Allow-Methods` | `GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS` |
+| `Access-Control-Allow-Headers` | `content-type, authorization` |
+
+`OPTIONS` preflight requests are handled automatically by the HTTP trigger handler.
+
+To override any of these defaults for a route, set the corresponding header on the response returned by your runnable using the [`windmill_headers`](../4_webhooks/index.mdx#custom-response-headers) mechanism. Only headers that are **not** already present in the response are filled in with the defaults above, so you can restrict origins or allowed headers on a per-route basis:
+
+```ts
+export async function main() {
+  return {
+    windmill_headers: {
+      "Access-Control-Allow-Origin": "https://app.example.com",
+      "Access-Control-Allow-Methods": "GET, POST",
+      "Access-Control-Allow-Headers": "content-type, x-api-key"
+    },
+    result: { ok: true }
+  };
 }
 ```
 

--- a/docs/core_concepts/40_websocket_triggers/index.mdx
+++ b/docs/core_concepts/40_websocket_triggers/index.mdx
@@ -69,6 +69,8 @@ The trigger also supports additional configuration options:
 If you enable the "Send runnable result" toggle, the runnable result will be sent to the WebSocket server as a message, as long as the job is a success and the result is not null.
 Like for [sync webhooks](../4_webhooks/index.mdx#synchronous), if the flow has the [early return](../../flows/19_early_return.mdx) setting set, the chosen node result will be sent and the rest of the flow will continue asynchronously.
 
+By default, only successful results are sent back. Enable the "Send result even on error" toggle to also forward error results to the WebSocket server, so the remote peer can react to failures (e.g. reply with an error frame). When disabled, failed jobs produce no outgoing message.
+
 
 ### Initial messages
 
@@ -84,9 +86,15 @@ The messages are sent in the order they are specified.
 ### Filters
 
 
-Instead of having all messages trigger the runnable, you can specify filters to only trigger the runnable when the message matches all filters.
+Instead of having all messages trigger the runnable, you can specify filters to restrict which messages trigger the runnable.
 Windmill supports the following filter:
 - **JSON**: The message is parsed as a JSON object and the filter checks that the filter `key` exists and the value at the key is equal or is a subset of the filter `value`.
+
+When multiple filters are configured, a filter logic selector lets you choose how they are combined:
+- **AND** (default): the message must match all filters to trigger the runnable.
+- **OR**: the message triggers the runnable as soon as it matches any one of the filters.
+
+Existing triggers without an explicit filter logic default to **AND**. The selector is only shown when at least one filter is present.
 
 ![Filters](./filters.png 'Filters')
 

--- a/docs/core_concepts/41_kafka_triggers/index.mdx
+++ b/docs/core_concepts/41_kafka_triggers/index.mdx
@@ -312,7 +312,11 @@ Each filter is a key/value pair where:
 - **Key**: A path into the JSON-decoded message (e.g. `type`, `data.status`)
 - **Value**: The expected value at that path (can be a string, number, object, or array)
 
-A message must match all filters (AND logic) to trigger the runnable. The matching uses a superset check — the message value at the given key must contain all fields from the filter value (additional fields in the message are allowed).
+When multiple filters are configured, a filter logic selector lets you choose how they are combined:
+- **AND** (default): the message must match all filters to trigger the runnable.
+- **OR**: the message triggers the runnable as soon as it matches any one of the filters.
+
+The matching uses a superset check — the message value at the given key must contain all fields from the filter value (additional fields in the message are allowed). Existing triggers without an explicit filter logic default to **AND**.
 
 Filters can be configured in the Kafka trigger editor UI using the filter section. You can add multiple key/value pairs, and a human-readable preview is shown for each filter (e.g. `payload.type == "order_created"`).
 

--- a/docs/core_concepts/4_webhooks/index.mdx
+++ b/docs/core_concepts/4_webhooks/index.mdx
@@ -41,6 +41,21 @@ version of the Script/Flow and the other one with just a hash, i.e. `/h/<hash>`,
 hiding potentially sensitive information and always corresponding to that
 version of the script, even with overwrites.
 
+#### Version-pinned webhooks (flows)
+
+Flows additionally expose version-pinned webhook endpoints that target a specific flow version by its numeric version ID instead of the latest deployment. They use the `fv/<version>` path segment and are available in the Triggers tab of the flow:
+
+```bash
+# async
+/api/w/<workspace>/jobs/run/fv/<version>
+# sync
+/api/w/<workspace>/jobs/run_wait_result/fv/<version>
+# SSE stream
+/api/w/<workspace>/jobs/run_and_stream/fv/<version>
+```
+
+Unlike the script `/h/<hash>` endpoint, the flow-by-version URL is stable across redeploys and guarantees that integrations keep calling the exact flow version they were tested against, even after new versions are published. Callers still need a token with permission to run the flow.
+
 #### Asynchronous
 
 Jobs can be triggered in asynchronous mode, meaning that the webhook is triggered, and the returning value is the uuid of the job assigned to execute the underlying code

--- a/docs/core_concepts/54_ai_agents/index.mdx
+++ b/docs/core_concepts/54_ai_agents/index.mdx
@@ -42,6 +42,16 @@ Each script tool must have a unique name within the AI agent step and contain on
 
 When script tools are configured, the AI agent can decide when and how to use them based on the user's request. It selects the most appropriate tool by name, and issues a tool call with JSON arguments that conform to the tool's input schema. Windmill executes the underlying `script` and returns a JSON result, which is surfaced back to the model as a tool response message and is included in `messages`.
 
+### Websearch tool
+
+AI Agents can be equipped with a built-in websearch tool to retrieve up-to-date information from the web during execution. Websearch is supported on OpenAI, Anthropic, and Google AI (Gemini) providers, and uses each provider's native web search capability (OpenAI's web search tool via the Responses API, Anthropic's web search tool, and Gemini's Google Search grounding). Add it from the tool picker of the AI Agent step — no additional configuration is required.
+
+### Nested AI agents (agent as tool)
+
+An AI Agent can be used as a tool inside another AI Agent step, enabling hierarchical or specialized sub-agents (for example, a coordinator agent that delegates to a research agent). When adding a tool to an AI Agent step, pick "AI Agent" as the tool type and configure the nested agent with its own provider, model, system prompt, tools, memory, and other input transforms — the full input transforms view is available, so the nested agent can be configured just like a regular AI Agent step.
+
+Only two levels of nesting are supported: `flow → AI agent → nested AI agent tool`. A nested AI agent cannot itself contain further AI agent tools; attempting deeper nesting is rejected at runtime.
+
 ### MCP tools
 
 AI Agents can connect to [MCP (Model Context Protocol)](../51_mcp/index.mdx) servers as tools, enabling access to any tools exposed by MCP-compatible servers.
@@ -160,8 +170,17 @@ If the AI agent step is not the last step of your flow, make sure to configure [
 The `new_result_stream` field of an SSE event can contain multiple payloads at a time, make sure to split on line breaks.
 Only complete payloads are streamed, you do not need to handle partial JSON.
 
-#### user_images (optional)
-Allows you to pass images as input to the AI model for analysis, processing, or context. The AI can analyze the image content and respond accordingly. Requires an [S3 object storage](../38_object_storage_in_windmill/index.mdx) to be configured at the workspace level.
+#### user_attachments (optional)
+Allows you to pass images or PDF documents as input to the AI model for analysis, processing, or context. The AI can analyze the attachment content and respond accordingly. Requires an [S3 object storage](../38_object_storage_in_windmill/index.mdx) to be configured at the workspace level.
+
+Supported attachment types:
+- **Images**: analyzed as visual content across all providers that support vision input.
+- **PDF documents**: supported on Anthropic (sent as `document` content blocks), OpenAI (sent as `input_file` blocks), and Google AI (Gemini, natively supported via inline data). The MIME type is detected automatically from the file extension.
+
+The field was previously named `user_images`; flows using the old name continue to work through backward-compatible deserialization.
+
+#### max_iterations (number, optional)
+Maximum number of tool-calling iterations the agent is allowed to perform in a single run. Each iteration corresponds to one round-trip where the model can choose to call tools; once the limit is reached, the agent stops and returns its current output. Use this to bound cost and runtime, or to prevent runaway agents that get stuck in tool-calling loops.
 
 #### max_completion_tokens (number)
 Controls the maximum number of tokens the AI can generate in its response. This helps manage costs and ensures responses stay within desired length limits.
@@ -234,9 +253,29 @@ Only in text output mode, contains the complete conversation history, including:
 
 The `messages` array provides full visibility into the AI's reasoning process and tool usage, which can be useful for debugging, logging, or understanding how the AI reached its conclusion.
 
+#### usage (optional)
+
+Contains token usage information for the AI agent run, accumulated across all iterations (including tool calls). Fields include `input_tokens`, `output_tokens`, `total_tokens`, and — for providers that support prompt caching — `cache_read_input_tokens` and `cache_write_input_tokens`.
+
+```json
+{
+  "usage": {
+    "input_tokens": 1234,
+    "output_tokens": 567,
+    "total_tokens": 1801
+  }
+}
+```
+
+Usage tracking is supported on Anthropic, AWS Bedrock, Google AI (Gemini), OpenAI (Responses API), Azure OpenAI / Chat Completions, and OpenRouter. If a provider does not support the `stream_options.include_usage` parameter, Windmill automatically retries the request without it.
+
 #### wm_stream (optional)
 
 Only included in streaming mode, contains the complete stream.
+
+### Anthropic prompt caching
+
+For Anthropic models (including Vertex AI Anthropic), Windmill automatically applies `cache_control: { "type": "ephemeral" }` to the system prompt, the last custom tool definition, and the last content block of the last message on every request. This reduces token costs and latency on multi-turn conversations and iterative tool use, since Anthropic can reuse the cached prefix across calls. Cache hits are reflected in the `cache_read_input_tokens` and `cache_write_input_tokens` fields of the `usage` output. No configuration is required — caching is applied transparently whenever an Anthropic-based provider is used.
 
 ## Debugging
 

--- a/docs/core_concepts/59_user_tokens/index.mdx
+++ b/docs/core_concepts/59_user_tokens/index.mdx
@@ -94,7 +94,7 @@ Multiple paths can be combined with commas: `scripts:read:f/production/*,f/stagi
 
 When calling an [HTTP trigger](../39_http_routing/index.mdx) with Windmill Auth, the token must have `http_triggers:read` access to the trigger path. For example, a scoped token calling an HTTP route at `my_route` needs `http_triggers:read:my_route`.
 
-When configuring an HTTP trigger with **Windmill Auth**, you can generate a pre-scoped token directly from the trigger configuration page.
+When configuring an HTTP trigger with **Windmill Auth**, you can generate a pre-scoped token directly from the trigger configuration page. See [Token scopes for HTTP routes](../39_http_routing/index.mdx#token-scopes) for details.
 
 ## Webhook-specific tokens
 

--- a/docs/core_concepts/60_labels/index.mdx
+++ b/docs/core_concepts/60_labels/index.mdx
@@ -1,0 +1,108 @@
+---
+description: How do I organize scripts, flows, apps, resources, variables, schedules, and triggers with labels in Windmill?
+---
+
+import DocCard from '@site/src/components/DocCard';
+
+# Labels
+
+Labels are free-form tags that you can attach to any item in a workspace to organize, group, and filter them. Labels are purely informational — they do not affect execution — but they propagate to jobs at runtime so you can trace a job back to the labels on its source script or flow.
+
+Labels are supported on:
+
+- Scripts
+- Flows
+- Apps (including raw/full-code apps)
+- Resources
+- Variables
+- Schedules
+- Triggers (all trigger types: HTTP routes, webhooks, websocket, Kafka, NATS, MQTT, SQS, GCP, Postgres)
+
+<div className="grid grid-cols-2 gap-6 mb-4">
+	<DocCard
+		title="Monitor past and future runs"
+		description="Filter jobs by labels to monitor specific groups of runs."
+		href="/docs/core_concepts/monitor_past_and_future_runs"
+	/>
+	<DocCard
+		title="Groups and folders"
+		description="Organize items into folders for permission management."
+		href="/docs/core_concepts/groups_and_folders"
+	/>
+</div>
+
+## Adding labels
+
+Every editor and creation drawer includes a **Labels** input where you can type or paste labels. Labels are free-form strings — you can create a new label by typing it and pressing `Enter`, or pick an existing label from the autocomplete dropdown.
+
+The autocomplete is powered by the `/labels/list` endpoint, which returns all labels that already exist in the workspace across every item type. This makes it easy to reuse the same label vocabulary across scripts, flows, resources, and triggers without having to remember exact spellings.
+
+You can edit the labels of an existing item at any time from its editor — changes are saved with the next deploy/save action.
+
+## Label badges on list pages
+
+Items that have labels display their labels as small blue badges on every list page (Scripts, Flows, Apps, Resources, Variables, Schedules, Triggers, and the home page). Each badge shows the label text prefixed with a tag icon, and hovering reveals a `Label: X` tooltip.
+
+When an item has more labels than fit inline, a `+N` badge is rendered. Hovering `+N` shows the remaining labels.
+
+### Clickable badges to filter
+
+Clicking any badge toggles that label as a filter on the current list view. Click again to remove it. This makes it trivial to jump from a single item's badge to the full list of items sharing that label.
+
+## Filtering by label
+
+All list endpoints and list pages accept a `label` query parameter:
+
+```
+GET /api/w/{workspace}/scripts/list?label=production
+```
+
+### Multi-label filtering
+
+The `label` query parameter accepts a comma-separated list of labels. The filter is inclusive — items matching **any** of the labels are returned:
+
+```
+GET /api/w/{workspace}/flows/list?label=production,critical
+```
+
+In the UI, clicking multiple label badges or selecting multiple labels from the filter dropdown appends them to the filter as a comma-separated value.
+
+### Filter presets
+
+The search bar on Resources, Variables, and Schedules pages (and Folders) surfaces **label presets**: the most common labels already present in the loaded items appear as one-click filter presets. Selecting a preset appends it to the current label filter.
+
+Presets that are already active in the current filter are hidden so the suggestions stay fresh.
+
+## The `/labels/list` endpoint
+
+Windmill exposes an autocomplete endpoint that returns every distinct label currently used in the workspace:
+
+```
+GET /api/w/{workspace}/labels/list
+```
+
+This endpoint aggregates labels across all item types (scripts, flows, apps, resources, variables, schedules, triggers) and returns the union as a sorted list. The Labels input in every editor consumes this endpoint to power its dropdown.
+
+## Propagation to jobs
+
+When a script or flow is executed, its labels are merged into the job's labels at dispatch time. The job's `labels` column on `v2_job` contains the union of:
+
+- The labels of the script/flow being run
+- Any `wm_labels` returned by the script's main function (see [Jobs labels](../5_monitor_past_and_future_runs/index.mdx#jobs-labels))
+
+This means filtering jobs by label on the Runs page will match jobs whose underlying script/flow had a given label, even if the script itself did not emit `wm_labels`. The Runs page label filter supports wildcards (`*`) and comma-separated multi-label filtering.
+
+![Run labels](../5_monitor_past_and_future_runs/runs_labels.png 'Runs page filtered by label')
+
+<div className="grid grid-cols-2 gap-6 mb-4">
+	<DocCard
+		title="Jobs"
+		description="Jobs are the unit of execution in Windmill."
+		href="/docs/core_concepts/jobs"
+	/>
+	<DocCard
+		title="Monitor past and future runs"
+		description="Filter jobs by labels, tags, workers, and more."
+		href="/docs/core_concepts/monitor_past_and_future_runs"
+	/>
+</div>

--- a/docs/flows/1_flow_editor.mdx
+++ b/docs/flows/1_flow_editor.mdx
@@ -70,6 +70,55 @@ Another approach is to write a program that defines the jobs and their dependenc
 	/>
 </div>
 
+## Flow groups
+
+Flow groups visually cluster related steps in the flow editor. A group renders as a colored border around its contained nodes with a header card, and behaves as a single unit for comments, navigation, and run-page display.
+
+**Creating and editing groups:**
+
+- Select multiple nodes (drag-box selection or shift-click), then create a group from the bounding-box action menu.
+- Each group has an overlay action bar with: **collapse/expand**, a **color picker**, a **"collapsed by default"** toggle, and an **ungroup** action.
+- Double-click the group header to add a markdown description; groups support GitHub-flavored Markdown for rich documentation on the canvas.
+
+**Collapsible groups:**
+
+- Click the minimize button on the group to collapse it into a single node (similar to a subflow). Click again to expand.
+- The runtime collapsed/expanded state is ephemeral (per-session).
+- Toggling **"Collapsed by default"** is a persistent setting saved in the flow YAML — the group will render collapsed the next time the flow is loaded.
+- Groups and notes are shown in the flow status viewer, both on the run page and in the editor preview, so the visual grouping you designed is preserved when reviewing runs.
+
+See also [Sticky notes](./24_sticky_notes.mdx) for free-floating markdown notes on the canvas.
+
+## Node manipulation
+
+Windmill's flow editor supports several ways to rearrange, duplicate, and remove nodes:
+
+**Drag-and-drop reordering**
+
+- Each flow node has a **move** handle; drag it to reorder the node anywhere in the flow.
+- Dragging a subflow (for-loop, branchall, branchone) shows a live ghost of the full subflow graph — scaled to viewport zoom — so you can see exactly what you're moving.
+- Valid drop zones are highlighted in green as you approach them, with proximity cues guiding the drop.
+- All nested descendants of a dragged subflow fade visually so you can see which nodes will move together.
+- Press `Escape` during a drag to cancel cleanly.
+
+**Node context menu**
+
+Right-click any node in edit mode to open its context menu:
+
+- **Move** — enters the legacy click-to-move mode (same as the hover-button move).
+- **Duplicate** — clones the node and all of its nested children, reassigning IDs, and inserts the clone right after the original.
+- **Delete** — removes the node (shown in red as a danger action).
+- **Add note** — attaches a sticky note to the node.
+
+**Multi-select actions**
+
+- Enter selection mode from the top-right of the flow pane, then drag-box or shift-click to select multiple nodes.
+- The bounding-box action menu supports multi-select **move**, **duplicate**, and **delete** in one action.
+- Per-node action buttons (ellipsis, delete, test/run, output picker, expand subflow) are hidden during multi-selection so the canvas stays clean.
+- While in selection mode, hold `Ctrl`/`Cmd` to temporarily pan the canvas; while in pan mode, hold `Ctrl`/`Cmd` to temporarily select nodes.
+
+## Features
+
 The Flow editor has the following features which are the subject of specific pages:
 
 <div className="grid grid-cols-2 gap-6 mb-4">

--- a/docs/flows/26_flow_as_chat.mdx
+++ b/docs/flows/26_flow_as_chat.mdx
@@ -1,0 +1,83 @@
+---
+description: How do I turn a flow into a chatbot in Windmill? Enable chat input on a flow to converse with it, cancel runs, and display images and tool usage.
+---
+
+import DocCard from '@site/src/components/DocCard';
+
+# Flow as chat
+
+Flow as chat turns any flow into a conversational runtime. When enabled, the flow exposes a chat interface instead of (or in addition to) the traditional input form — users send messages, the flow runs once per turn, and each run's output is rendered as an assistant reply in the thread.
+
+This is different from **[AI Flow Chat](./17_ai_flows.mdx)** (the editor-side assistant that helps you build flows). Flow as chat is a **runtime** feature: it turns the finished flow itself into a chatbot that end-users interact with.
+
+## Enabling chat on a flow
+
+Open the flow in the editor and toggle **Chat input** on the flow's Input settings. Enabling chat sets `chat_input_enabled: true` on the flow definition (part of the OpenFlow spec).
+
+When chat is enabled, a chat-input virtual node is rendered on the flow graph to make it clear that the flow's main input comes from the chat interface rather than a form. The runtime passes two extra fields to the flow on every turn:
+
+- The user's latest chat message (as the flow's chat input argument)
+- A `memory_id` identifying the current conversation
+
+The flow is free to use the `memory_id` to load conversation history, persist state, or pass it to AI agent steps for multi-turn memory.
+
+## Conversations
+
+Every chat session is a **conversation**. Conversations are persisted server-side (tables `flow_conversation` and `flow_conversation_message`), so users can reopen past chats, resume where they left off, and browse history from the conversations sidebar.
+
+Each turn adds at least two messages to the conversation: the user's prompt and the assistant's reply. Tool usage steps, when shown, appear as additional messages threaded into the turn.
+
+## Running a flow as chat
+
+When a chat-enabled flow is opened in the runner, the form is replaced (or augmented) by a chat interface with:
+
+- A message list showing the conversation so far
+- A text input at the bottom
+- A sidebar listing past conversations, with the ability to create a new one, rename, or delete
+
+Sending a message starts a new flow run with the message as input. The assistant's reply is the flow's output, streamed or polled as it arrives.
+
+### Cancel button
+
+While a turn is in-flight, the **Send** button is replaced by a **Stop** button. Clicking Stop cancels the underlying queued job (via `JobService.cancelQueuedJob`) so a long-running flow doesn't block the conversation. Cancel works in both polling and streaming modes.
+
+### Image outputs
+
+If the flow's output contains image data (data URLs, base64-encoded images, or S3 objects resolving to images), the chat renders them inline in the assistant's reply. This lets chat flows return generated charts, screenshots, or AI-generated images without any extra configuration.
+
+### Tool usage display
+
+When a chat flow uses [AI agent steps](../core_concepts/54_ai_agents/index.mdx) that call tools, each tool invocation is displayed inline in the conversation as a collapsible message. Tool messages show:
+
+- The tool name (and flow step name)
+- A success indicator (green check or red cross)
+- The tool's arguments and result (expandable)
+
+This makes it easy for end-users to see what the agent did on their behalf, and for developers to debug multi-step agent runs.
+
+<div className="grid grid-cols-2 gap-6 mb-4">
+	<DocCard
+		color="teal"
+		title="AI agents"
+		description="Integrate AI agent steps directly into your Windmill flows."
+		href="/docs/core_concepts/ai_agents"
+	/>
+	<DocCard
+		color="teal"
+		title="AI flows"
+		description="Generate flows from prompts with the editor-side AI assistant."
+		href="/docs/flows/ai_flows"
+	/>
+	<DocCard
+		color="teal"
+		title="Testing flows"
+		description="Iterate quickly and get control on your flow testing."
+		href="/docs/flows/test_flows"
+	/>
+	<DocCard
+		color="teal"
+		title="Flow editor components"
+		description="Details on the flow editor's major components."
+		href="/docs/flows/editor_components"
+	/>
+</div>

--- a/docs/misc/9_guides/otel/index.mdx
+++ b/docs/misc/9_guides/otel/index.mdx
@@ -86,12 +86,33 @@ The following tags are useful to filter for specific traces:
 - `parent_job`: The ID of the parent job (flow)
 - `flow_step_id`: The ID of the step within the workflow
 - `script_path`: The path of the script
+- `script_hash`: Hex hash of the deployed script version (lets you correlate failures with a specific deploy)
 - `workspace_id`: The name of the workspace
 - `worker_id`: The ID of the worker
 - `language`: The language of the script
 - `tag`: The queue tag of the workflow
+- `job_kind`: Job type — `script`, `flow`, `appscript`, `aiagent`, `preview`, `flowscript`, etc.
+- `trigger_kind`: How the job was triggered — `schedule`, `webhook`, `kafka`, `http`, `sqs`, etc.
+- `trigger`: Trigger identifier, e.g. the schedule path `f/elt/crm_ingestion_schedule`
+- `created_by`: User or system that started the job (`u/admin`, `schedule`, …)
+
+These attributes are recorded on both the `job` and `job_postprocessing` spans, so you can build dashboards in Sentry/Honeycomb/Datadog that break down execution by trigger source or deploy version without joining to the Windmill DB.
 
 ![Jaeger Search](./jaeger_search.png)
+
+## OTEL trace context in jobs
+
+When OTEL tracing is enabled, Windmill exposes the trace context of each job as environment variables inside the job's runtime, so user scripts can propagate trace context to downstream services:
+
+| Env var | Description |
+|---------|-------------|
+| `TRACEPARENT` | W3C Trace Context header value: `00-{trace_id}-{span_id}-01` |
+| `OTEL_TRACE_ID` | Hex-encoded trace ID (derived from the job UUID) |
+| `OTEL_SPAN_ID` | Hex-encoded span ID (derived from the job UUID) |
+
+These variables are set for Python, Bash, Bun, Deno, Go, TypeScript, Rust, C#, Ruby, Nu, Java, and PHP jobs. You can, for example, forward `TRACEPARENT` on outbound HTTP calls so that downstream services create child spans under the Windmill job span.
+
+When OTEL tracing is disabled (or on Community Edition), these env vars are not set.
 
 ## Monitoring metrics with Jaeger
 
@@ -204,6 +225,50 @@ exporters:
 In the Jaeger UI, you will now be able to see metrics time series for the traces in the "Monitor" tab.
 
 ![Jaeger Metrics](./jaeger_metrics.png)
+
+# Metrics
+
+In addition to traces and logs, Windmill can export its own operational metrics to any OTLP-compatible collector. Enable the **Metrics** toggle in **Instance settings > OTEL/Prom** — metrics are then exported alongside traces and logs to the same collector endpoint.
+
+These metrics complement the [Prometheus `/metrics` endpoint](../../../advanced/18_instance_settings/index.mdx#prometheus) on port 8001: the Prometheus endpoint is scraped by your monitoring system, while the OTEL metrics are pushed to the collector you configured for tracing.
+
+Flipping the toggle triggers a delayed worker restart so the OTLP meter provider can be initialized.
+
+## Exported metrics
+
+| Metric | Type | Attributes |
+|---|---|---|
+| `windmill.queue.push_count` | Counter | — |
+| `windmill.queue.delete_count` | Counter | — |
+| `windmill.queue.pull_count` | Counter | — |
+| `windmill.queue.zombie_restart_count` | Counter | — |
+| `windmill.queue.zombie_delete_count` | Counter | — |
+| `windmill.queue.count` | Gauge | `tag` |
+| `windmill.queue.running_count` | Gauge | `tag` |
+| `windmill.worker.started` | Counter | — |
+| `windmill.worker.uptime` | Gauge | `worker` |
+| `windmill.worker.execution_count` | Counter | `tag` |
+| `windmill.worker.execution_duration` | Histogram | `tag` |
+| `windmill.worker.execution_failed` | Counter | `tag` |
+| `windmill.worker.busy` | Gauge | `worker` |
+| `windmill.worker.pull_duration` | Histogram | `worker`, `has_job` |
+| `windmill.db.pool.active` | Gauge | — |
+| `windmill.db.pool.idle` | Gauge | — |
+| `windmill.db.pool.max` | Gauge | — |
+| `windmill.health.db_latency` | Gauge | — |
+| `windmill.health.db_unresponsive` | Gauge | — |
+| `windmill.health.status` | Gauge | `phase` |
+
+Metrics export is an [Enterprise Edition](/pricing) feature.
+
+## Selecting the exporter protocol
+
+The **OTEL/Prom** instance settings tab exposes a **Protocol** dropdown that applies to all three signal types (traces, logs, metrics):
+
+- **grpc** (default): uses the tonic gRPC client against the collector's OTLP gRPC endpoint (typically port `4317`).
+- **http/protobuf**: uses an HTTP client against the collector's OTLP HTTP endpoint (typically port `4318`). This is equivalent to setting `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
+
+Use `http/protobuf` when your network or collector does not support gRPC (for example, some managed observability backends only expose HTTP endpoints).
 
 # Tracing with Tempo and Grafana
 

--- a/docs/misc/9_guides/otel/index.mdx
+++ b/docs/misc/9_guides/otel/index.mdx
@@ -226,7 +226,7 @@ In the Jaeger UI, you will now be able to see metrics time series for the traces
 
 ![Jaeger Metrics](./jaeger_metrics.png)
 
-# Metrics
+## Exporting Windmill metrics via OTLP
 
 In addition to traces and logs, Windmill can export its own operational metrics to any OTLP-compatible collector. Enable the **Metrics** toggle in **Instance settings > OTEL/Prom** — metrics are then exported alongside traces and logs to the same collector endpoint.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -420,6 +420,7 @@ const sidebars = {
 				'core_concepts/workspace_dependencies/index',
 				'core_concepts/workspace_settings/index',
 				'core_concepts/streaming/index',
+				'core_concepts/labels/index',
 				{
 					type: 'category',
 					label: 'Integrations',
@@ -783,7 +784,8 @@ const sidebars = {
 						'flows/flow_approval',
 						'flows/sleep',
 						'flows/step_mocking',
-						'flows/sticky_notes'
+						'flows/sticky_notes',
+						'flows/flow_as_chat'
 					],
 					collapsed: true
 				},


### PR DESCRIPTION
## Summary

Fills documentation gaps identified by analyzing the **last 1000 `feat:` commits** on the main windmill repo (dates: 2025-07 → 2026-04) and cross-referencing them against the docs in this repo.

24 files touched (+1042 / -11), including **4 new pages**.

## Coverage added

### Triggers
- HTTP triggers: enable/disable, CORS headers, token scopes, workspace prefix enforcement (windmill-labs/windmill#6976, #6786, #7385, #8528)
- WebSocket triggers: send result on error toggle, AND/OR filter logic (#6664, #8580)
- Kafka triggers: AND/OR filter logic (#8580)
- Webhooks: version-pinned flow webhooks (#7062)
- Email triggers: enable/disable, custom TLS cert, git sync (#7171, #7415, #6582)

### AI
- AI agents: websearch tool, nested agents, `user_attachments` (PDF input), `max_iterations`, token usage output, Anthropic prompt caching (#7399, #8031, #8525, #7302, #7738)
- AI providers: Bedrock (IAM/session tokens/bearer/ambient role), Anthropic 1M context, Vertex AI for Gemini and Claude, `base_url` overrides, custom headers on customai, `AI_HTTP_HEADERS` env var, instance-level AI settings (#7131, #7155, #7379, #7654, #7891, #7908, #8303, #8364, #6994, #8453)

### CLI
- **New file** `docs/advanced/3_cli/lint.md` — `wmill lint` + `--locks-required` (#7917, #8026)
- **New file** `docs/advanced/3_cli/dev-preview.md` — `wmill flow dev` / `script preview` / `flow preview` (#7729)
- `wmill group`/`audit`/`token`/`schedule enable-disable` (#8581)
- `wmill workspace list`, `wmill docs`, `wmill folder add-missing` (#8047, #8114, #8011, #8480)
- `wmill config reference`, `nonDottedPaths`, unified `get`/`list`/`new` (#8546, #7459, #8047)

### New pages
- **`docs/core_concepts/60_labels/index.mdx`** — asset-level labels on all workspace items (#8609)
- **`docs/flows/26_flow_as_chat.mdx`** — turn a flow into a runtime chatbot (#6658, #6869, #6880, #6771)

### Instance settings / observability
- WebSocket base url instance setting (#8405)
- OTEL metrics, http/protobuf protocol, trace-context env vars in jobs, enriched span tags (#8442, #8702, #8277)
- Object storage usage view + manual log cleanup (#8724)
- Disable hub, docker registries, max index time window (#8225, #8290)

### Secrets
- Secret masking in job logs (#8520)
- HashiCorp Vault + Azure Key Vault backends (#7599, #8704)
- Multiline secrets, sensitive non-string fields, multi-secret resources (#8637, #8635, #8386)

### Data tables
- Schemas, type-checked queries, Database Studio integration, Postgres trigger source, agent worker support (#7353, #7381, #7930, #8088, #8697)

### Flow editor
- Flow groups (collapsible), node manipulation (drag/context menu) (#8075, #8076, #8050, #8204, #8535)

## Test plan

- [ ] `npm run build` passes locally
- [ ] Sidebar validates (`node -e "require('./sidebars.js')"` — already passing)
- [ ] New pages render with proper frontmatter and DocCards
- [ ] Links between new and existing pages resolve
- [ ] Spot-check that added sections match the actual product behavior

## Notes

- This is a broad sweep based on PR bodies and source code — please skim for factual accuracy, especially around enterprise-only features.
- Some gaps from the analysis remain uncovered (flow conditional retries, workspace forks data-table specifics, codebase ESM bundles, PowerShell workspace deps, runner groups details, etc.) — a follow-up PR can address those.
- A tracking doc with the full gap inventory can be shared separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)