### PR TITLE
docs(cli): unify wmill.yaml under workspaces key

### DIFF
--- a/changelog/2026-04-10-cli-workspaces-unification/index.md
+++ b/changelog/2026-04-10-cli-workspaces-unification/index.md
@@ -1,0 +1,17 @@
+---
+slug: cli-workspaces-unification
+title: Unified wmill.yaml workspaces config
+tags: ['wmill CLI', 'Local development']
+description: The CLI now uses a single `workspaces` key in `wmill.yaml` instead of `gitBranches`, `environments`, and `git_branches`. Workspace names are human-friendly, `gitBranch` and `workspaceId` default to the key name, and a new `--workspace` flag selects the target. Legacy configs still work — run `wmill config migrate` to convert.
+features:
+  [
+    'Single `workspaces:` key replaces `gitBranches`, `environments`, and `git_branches` in `wmill.yaml`',
+    'Workspace names are human-friendly identifiers — `gitBranch` and `workspaceId` default to the key when omitted',
+    'New `--workspace` global flag resolves config → profile automatically via `baseUrl` + `workspaceId` matching',
+    '`wmill config migrate` auto-converts legacy configs to the new format in one command',
+    '`wmill workspace bind` / `unbind` interactively create and remove `workspaces:` entries from the active profile',
+    '`wmill init` revamped: interactive workspace setup from existing profiles',
+    'Fully backward compatible: old `gitBranches`/`environments`/`git_branches` configs keep working with a one-time deprecation warning',
+  ]
+docs: /docs/advanced/cli/sync#workspaces
+---

--- a/docs/advanced/11_git_sync/index.mdx
+++ b/docs/advanced/11_git_sync/index.mdx
@@ -371,9 +371,9 @@ Git sync settings can be controlled via the [`wmill.yaml`](../3_cli/sync.mdx#wmi
 
 - **CLI compatibility**: Settings configured in the UI are compatible with [Windmill CLI](../3_cli/index.mdx)
 - **Version-controlled configuration**: Your sync settings are stored in git alongside your code
-- **Branch-specific overrides**: Different sync behavior per git branch
-- **Git Promotion-specific settings**: Special configuration for deployment workflows
-- **[Environment-specific items](../3_cli/environment-specific-items.mdx)**: Different versions of resources and variables per environment
+- **Workspace-specific overrides**: Different sync behavior per workspace (resolved from the current git branch or `--workspace`)
+- **Git promotion-specific settings**: Special configuration for deployment workflows
+- **[Workspace-specific items](../3_cli/environment-specific-items.mdx)**: Different versions of resources and variables per workspace
 
 The frontend will detect existing `wmill.yaml` files and merge settings appropriately.
 

--- a/docs/advanced/20_workspace_forks/index.mdx
+++ b/docs/advanced/20_workspace_forks/index.mdx
@@ -54,7 +54,7 @@ Key features:
 #### From the CLI
 
 1. Enter the local repo being synced with the workspace you want to fork.
-2. Run `wmill workspace fork` and follow the prompts to name your workspace. This will use your `gitBranches` settings on your `wmill.yaml` to determine which workspace to fork from based on the branch you are on.
+2. Run `wmill workspace fork` and follow the prompts to name your workspace. This uses your `workspaces` settings in `wmill.yaml` to determine which workspace to fork from based on the branch you are on.
 3. The fork will be created on your instance and is ready to be worked on.
 4. Run the command shown on your terminal to create the corresponding branch and start adding edits to your newly created fork!
 

--- a/docs/advanced/23_canonical_deployment_setups/index.mdx
+++ b/docs/advanced/23_canonical_deployment_setups/index.mdx
@@ -304,7 +304,7 @@ For additional safety, enable [protection rulesets](../../core_concepts/56_prote
 - PR-based code review with your existing tools
 - Separate dev and prod environments
 - Works across Windmill instances
-- Environment-specific configurations via [environment-specific items](../3_cli/environment-specific-items.mdx)
+- Per-workspace configurations via [workspace-specific items](../3_cli/environment-specific-items.mdx)
 - Developers can work independently in forks
 - Maximum flexibility for development workflows
 

--- a/docs/advanced/3_cli/environment-specific-items.mdx
+++ b/docs/advanced/3_cli/environment-specific-items.mdx
@@ -1,91 +1,45 @@
 ---
-description: How do I configure environment-specific resources in Windmill? Set up per-environment resources and variables with multi-branch or single-branch workflows.
+description: How do I configure per-workspace resources and variables in Windmill? Store different versions of resources, variables, triggers, folders, and settings per workspace on disk.
 ---
 
-# Environment-specific items
+# Workspace-specific items
 
-Environment-specific items allow you to have different versions of [resources](../../core_concepts/3_resources_and_types/index.mdx) and [variables](../../core_concepts/2_variables_and_secrets/index.mdx) per environment/branch (dev/staging/prod). The CLI automatically transforms file paths so that each environment gets its own namespaced files locally while maintaining clean base paths in the Windmill workspace.
+Workspace-specific items let you store different versions of
+[resources](../../core_concepts/3_resources_and_types/index.mdx),
+[variables](../../core_concepts/2_variables_and_secrets/index.mdx), triggers, folders, and
+workspace settings per workspace (dev / staging / prod). The CLI transforms file paths so
+that each workspace has its own namespaced files locally while keeping clean base paths in
+the Windmill workspace itself.
+
+This replaces the older split between `gitBranches` (multi-branch) and `environments`
+(single-branch). Both are now a single `workspaces:` key — see
+[Migrating from `gitBranches` / `environments`](./sync.mdx#migrating-from-gitbranches--environments).
 
 ## How it works
 
-When a file matches a pattern in your `wmill.yaml` configuration, the CLI inserts the environment name into the local file path:
+When a file matches a pattern in your `wmill.yaml` configuration, the CLI inserts the
+workspace name into the local file path:
 
 - **Local files**: `database.dev.resource.yaml`, `database.prod.resource.yaml`
 - **Windmill workspace**: `database.resource.yaml` (clean base path)
 
-This lets each environment have its own configuration for the same logical resource. In practice, multiple environment files usually end up coexisting in the repository (e.g. `database.dev.resource.yaml` and `database.prod.resource.yaml` side by side) — by design in single-branch setups, or as a result of merging branches in multi-branch setups. The CLI only reads the files matching the current environment and ignores the others.
+Each workspace has its own version of the same logical resource. In practice, multiple
+workspace-specific files usually coexist in the repository (e.g. `database.dev.resource.yaml`
+and `database.prod.resource.yaml` side by side) — by design when one git branch hosts
+multiple workspaces, or as a result of merging branches when each workspace has its own
+branch. The CLI only reads the files matching the current workspace and ignores the others.
 
-Two workflows are supported to define environments:
+## Configuration
 
-- **Multi-branch** — each git branch is an environment, detected automatically. Use the `gitBranches` key in `wmill.yaml`.
-- **Single-branch** — one git branch, environments are defined explicitly. Use the `environments` key in `wmill.yaml` and the `--env` CLI flag.
-
-Both use the same path-transformation logic — only the configuration key differs.
-
-## Multi-branch setup
-
-Each git branch maps to an environment (e.g. `main` → production, `dev` → development). The CLI detects the current branch automatically.
-
-### Configuration
+Workspace-specific items are declared inside a `workspaces:` entry, either per workspace
+under `specificItems`, or shared across every workspace under `commonSpecificItems`.
 
 ```yaml
-gitBranches:
-  main:
-    specificItems:
-      resources:
-        - "u/alex/config/**"
-      variables:
-        - "u/alex/env_*"
-      triggers:
-        - "u/alex/kafka_*"
-      folders:
-        - "f/env_*"
-      settings: true
-    overrides:
-      skipSecrets: false
-
+workspaces:
   dev:
-    specificItems:
-      resources:
-        - "u/alex/config/**"
-      variables:
-        - "u/alex/env_*"
-      triggers:
-        - "u/alex/kafka_*"
-      folders:
-        - "f/env_*"
-      settings: true
+    baseUrl: https://dev.windmill.dev
     overrides:
       skipSecrets: true
-```
-
-### Usage
-
-The CLI automatically detects the current git branch and applies the matching configuration.
-
-```bash
-git checkout main
-wmill sync pull
-# Creates: u/alex/config/database.main.resource.yaml
-
-git checkout dev
-wmill sync pull
-# Creates: u/alex/config/database.dev.resource.yaml
-```
-
-You can override the detected branch with `--branch` (e.g. `wmill sync pull --branch main`).
-
-## Single-branch setup
-
-All environments are managed from a single git branch. You select the target environment with `--env`.
-
-### Configuration
-
-Use the `environments` key in `wmill.yaml`:
-
-```yaml
-environments:
-  dev:
     specificItems:
       resources:
         - "u/alex/config/**"
@@ -93,23 +47,15 @@ environments:
         - "u/alex/env_*"
       triggers:
         - "u/alex/kafka_*"
-      folders:
-        - "f/env_*"
-      settings: true
-    overrides:
-      skipSecrets: true
-
-  staging:
-    specificItems:
-      resources:
-        - "u/alex/config/**"
-      variables:
-        - "u/alex/env_*"
       folders:
         - "f/env_*"
       settings: true
 
   prod:
+    baseUrl: https://app.windmill.dev
+    gitBranch: main              # workspace "prod" lives on git branch "main"
+    overrides:
+      skipSecrets: false
     specificItems:
       resources:
         - "u/alex/config/**"
@@ -118,23 +64,69 @@ environments:
       folders:
         - "f/env_*"
       settings: true
-    overrides:
-      skipSecrets: false
+
+  # Items that are workspace-specific across ALL workspaces
+  commonSpecificItems:
+    resources:
+      - "u/alex/config/**"
+    variables:
+      - "u/alex/database_*"
+    folders:
+      - "f/env_*"
+    settings: true
 ```
 
-### Usage
+The `workspaces` key is the map key (`dev`, `prod`, …) and is also the suffix inserted into
+file names on disk. `gitBranch` and `workspaceId` default to that key — only set them when
+they differ.
+
+## Resolving the current workspace
+
+`wmill sync pull` and `wmill sync push` pick the workspace in this order:
+
+1. `--workspace <name>` — explicit override, looks up the entry by key.
+2. **Current git branch** — the first entry whose effective `gitBranch` matches
+   `git rev-parse --abbrev-ref HEAD`.
+3. No match — top-level sync options are used as-is, no workspace-specific transform.
+
+### One git branch per workspace
+
+Each workspace has its own git branch. The CLI detects the current branch automatically and
+applies the matching entry.
 
 ```bash
-wmill sync pull --env dev
-# Creates: u/alex/config/database.dev.resource.yaml
-
-wmill sync pull --env prod
+git checkout main
+wmill sync pull
+# Uses workspace "prod" (gitBranch: main)
 # Creates: u/alex/config/database.prod.resource.yaml
 
-wmill sync push --env staging
+git checkout dev
+wmill sync pull
+# Uses workspace "dev"
+# Creates: u/alex/config/database.dev.resource.yaml
 ```
 
-No `git checkout` is needed — all environment-specific files coexist on the same branch.
+### Multiple workspaces on one git branch
+
+All workspaces live on the same branch and you pick the target with `--workspace`.
+
+```bash
+wmill sync pull --workspace dev
+# Creates: u/alex/config/database.dev.resource.yaml
+
+wmill sync pull --workspace prod
+# Creates: u/alex/config/database.prod.resource.yaml
+
+wmill sync push --workspace staging
+```
+
+No `git checkout` is needed — all workspace-specific files coexist on the same branch.
+
+:::info Migrating from `--env` and `--branch`
+`--branch` and `--env` are still accepted on sync commands but are deprecated — they print a
+one-time warning and resolve the same way `--workspace` does. Update any scripts or CI jobs
+to use `--workspace` instead.
+:::
 
 ## File path transformation
 
@@ -152,20 +144,26 @@ No `git checkout` is needed — all environment-specific files coexist on the sa
 - `f/env_staging/folder.dev.meta.yaml` → `f/env_staging/folder.meta.yaml`
 - `settings.dev.yaml` → `settings.yaml`
 
+The suffix is the **workspace name** (the key in `workspaces:`). In migrated configs where
+the workspace name equals the old branch name, existing files keep working unchanged.
+
 ### Resource files
 
-Resources can include associated files (certificates, config files, etc.) alongside their YAML definitions. These follow the same transformation:
+Resources can include associated files (certificates, config files, etc.) alongside their
+YAML definitions. These follow the same transformation:
 
 - Base file: `u/alex/certificate.resource.file.pem`
-- Environment-specific: `u/alex/certificate.dev.resource.file.pem`
+- Workspace-specific: `u/alex/certificate.dev.resource.file.pem`
 
-When a resource YAML file is marked as environment-specific, all associated resource files are automatically treated the same way.
+When a resource YAML file is marked as workspace-specific, all associated resource files are
+automatically treated the same way.
 
 ### Supported file types
 
 - **Variables**: `*.variable.yaml`
 - **Resources**: `*.resource.yaml` and resource files (`*.resource.file.*`)
 - **Triggers**: `*.kafka_trigger.yaml`, `*.http_trigger.yaml`, `*.websocket_trigger.yaml`, `*.nats_trigger.yaml`, `*.postgres_trigger.yaml`, `*.mqtt_trigger.yaml`, `*.sqs_trigger.yaml`, `*.gcp_trigger.yaml`
+- **Schedules**: `*.schedule.yaml`
 - **Folders**: `folder.meta.yaml` files within folder directories
 - **Settings**: `settings.yaml` (workspace settings file)
 
@@ -180,61 +178,65 @@ Patterns support standard glob syntax:
 
 ## Common specific items
 
-Items that should be environment-specific across all environments can be defined with `commonSpecificItems`:
+Items that should be workspace-specific across all workspaces can be declared once under
+`commonSpecificItems`:
 
 ```yaml
-# Inside gitBranches or environments
-commonSpecificItems:
-  variables:
-    - "u/alex/database_*"
-    - "f/config/**"
-  resources:
-    - "u/alex/api_keys/**"
-    - "f/environments/**"
-  triggers:
-    - "u/alex/kafka_*"
-    - "f/streaming/**"
-  folders:
-    - "f/env_*"
-  settings: true
-```
-
-## Per-environment specific items
-
-If some resources only exist in certain environments, you can define different patterns per environment instead of using `commonSpecificItems`:
-
-```yaml
-# Inside gitBranches or environments
-prod:
-  specificItems:
+workspaces:
+  commonSpecificItems:
     variables:
-      - "u/alex/prod_*"
+      - "u/alex/database_*"
+      - "f/config/**"
     resources:
-      - "u/alex/production/**"
+      - "u/alex/api_keys/**"
+      - "f/environments/**"
     triggers:
-      - "u/alex/prod_kafka_*"
+      - "u/alex/kafka_*"
+      - "f/streaming/**"
     folders:
-      - "f/prod_config"
-    settings: true
-
-dev:
-  specificItems:
-    variables:
-      - "u/alex/dev_*"
-    resources:
-      - "u/alex/development/**"
-    triggers:
-      - "u/alex/dev_kafka_*"
-    folders:
-      - "f/dev_config"
+      - "f/env_*"
     settings: true
 ```
 
-Here, `prod_kafka_*` triggers only get the environment suffix on `prod` — they don't exist in `dev`, so there's no need to mark them there. Most setups use `commonSpecificItems` since the same resources typically exist across all environments.
+## Per-workspace specific items
+
+If some resources only exist in certain workspaces, define different patterns per workspace
+instead of using `commonSpecificItems`:
+
+```yaml
+workspaces:
+  prod:
+    specificItems:
+      variables:
+        - "u/alex/prod_*"
+      resources:
+        - "u/alex/production/**"
+      triggers:
+        - "u/alex/prod_kafka_*"
+      folders:
+        - "f/prod_config"
+      settings: true
+
+  dev:
+    specificItems:
+      variables:
+        - "u/alex/dev_*"
+      resources:
+        - "u/alex/development/**"
+      triggers:
+        - "u/alex/dev_kafka_*"
+      folders:
+        - "f/dev_config"
+      settings: true
+```
+
+Here, `prod_kafka_*` triggers only get the workspace suffix on `prod` — they don't exist in
+`dev`, so there's no need to mark them there. Most setups use `commonSpecificItems` since
+the same resources typically exist across all workspaces.
 
 ## Name safety
 
-Environment and branch names containing certain characters are automatically sanitized for filesystem safety:
+Workspace names containing certain characters are automatically sanitized for filesystem safety:
 
 - **Unsafe characters**: `/ \ : * ? " < > | .`
 - **Replacement**: All unsafe characters are replaced with `_`
@@ -245,40 +247,47 @@ Warning: Branch name "feature/api-v2.1" contains filesystem-unsafe characters (/
 and was sanitized to "feature_api-v2_1". This may cause collisions with other similarly named branches.
 ```
 
+Prefer simple workspace keys (`dev`, `staging`, `prod`) to avoid collisions.
+
 ## Best practices
 
 - **Start broad**: Use `commonSpecificItems` for widely-used resources
 - **Be specific**: Target exact paths rather than overly broad patterns
-- **Group logically**: Organize patterns by team, environment, or function
+- **Group logically**: Organize patterns by team, workspace, or function
 - **Define patterns early**: Establish patterns before team members start using them
-- **Test locally**: Verify environment-specific behavior works correctly before CI/CD integration
+- **Test locally**: Verify workspace-specific behavior works correctly before CI/CD integration
 
 ## Troubleshooting
 
-### Files not being detected as environment-specific
+### Files not being detected as workspace-specific
 
 1. **Check patterns**: Ensure your glob patterns match the file paths exactly
-2. **Verify file types**: Only variables, resources, resource files, and trigger files are supported
+2. **Verify file types**: Only the types listed above are supported
 3. **Pattern testing**: Use tools like [globster.xyz](https://globster.xyz/) to test your patterns
 
 ### Files syncing to the wrong workspace
 
-1. **Check config**: Ensure your environment configuration is correct
-2. **Verify current context**: Make sure you're on the expected git branch or using the right `--env` flag
+1. **Check config**: Ensure your `workspaces:` entry is correct
+2. **Verify current context**: Make sure you're on the expected git branch or using the right `--workspace` flag
 3. **Configuration precedence**: CLI flags override configuration file settings
 
 ## Git sync integration
 
-When [Git sync](../11_git_sync/index.mdx) is configured, environment-specific items work seamlessly with your Git repository setup. Git sync will automatically push changes to the correct environment-specific files based on the repository configuration.
+When [Git sync](../11_git_sync/index.mdx) is configured, workspace-specific items work
+seamlessly with your Git repository setup. Git sync pushes changes to the correct
+workspace-specific files based on the resolved workspace.
 
-**Multi-branch**: each workspace's `git_repository` resource points to a different branch. Git sync detects the branch and applies the matching `gitBranches` configuration automatically.
+- **One git branch per workspace**: each Windmill workspace's `git_repository` resource
+  points to a different branch. Git sync detects the branch and applies the matching
+  `workspaces:` entry automatically.
+  - **Production workspace**: `git_repository` pointing to `repoX` on `main` branch
+    - Changes to `database.resource.yaml` → pushed as `database.prod.resource.yaml`
+  - **Development workspace**: `git_repository` pointing to `repoX` on `dev` branch
+    - Changes to `database.resource.yaml` → pushed as `database.dev.resource.yaml`
 
-- **Production workspace**: `git_repository` pointing to `repoX` on `prod` branch
-  - Changes to `database.resource.yaml` → pushes to `database.prod.resource.yaml`
-- **Development workspace**: `git_repository` pointing to `repoX` on `dev` branch
-  - Changes to `database.resource.yaml` → pushes to `database.dev.resource.yaml`
-
-**Single-branch**: all workspaces point to the same branch. Set the environment name in the Git sync advanced settings so that Git sync applies the matching `environments` configuration.
+- **Multiple workspaces on one git branch**: all Windmill workspaces point to the same
+  branch. Set the workspace name in the Git sync advanced settings so Git sync applies the
+  matching `workspaces:` entry.
 
 ## Related documentation
 

--- a/docs/advanced/3_cli/gitsync-settings.mdx
+++ b/docs/advanced/3_cli/gitsync-settings.mdx
@@ -30,7 +30,7 @@ wmill gitsync-settings pull [options]
 | `--repository`                | `<repository>`        | Specify repository path (e.g., u/user/repo). If not specified, will auto-select if only one repository exists or prompt for selection.                                                                              |
 | `--default`                   | None                  | Write settings to top-level defaults instead of branch-specific overrides.                                                                                                                                          |
 | `--replace`                   | None                  | Replace existing settings (non-interactive mode). Overwrites top-level wmill.yaml settings.                                                                                                                         |
-| `--override`                  | None                  | Add branch-specific override (non-interactive mode). Creates branch-specific configuration in git_branches section.                                                                                                 |
+| `--override`                  | None                  | Add workspace-specific override (non-interactive mode). Creates or updates an entry under the `workspaces:` section.                                                                                                |
 | `--diff`                      | None                  | Show differences without applying changes. Preview what would be modified in your local configuration.                                                                                                              |
 | `--json-output`               | None                  | Output in JSON format. Useful for scripting and automation.                                                                                                                                                         |
 | `--with-backend-settings`     | `<json>`              | Use provided JSON settings instead of querying backend (primarily for testing purposes).                                                                                                                            |
@@ -85,7 +85,7 @@ The command handles these git-sync configuration fields (see [wmill.yaml](./sync
 The pull command supports different write modes when conflicts exist:
 
 - **Replace mode** (`--replace`): Overwrites top-level wmill.yaml settings
-- **Override mode** (`--override`): Creates environment-specific overrides in the `gitBranches` / `environments` section
+- **Override mode** (`--override`): Creates workspace-specific overrides in the `workspaces:` section
 - **Default mode** (`--default`): Writes to top-level defaults
 - **Interactive mode** (default): Prompts user to choose between replace/override when conflicts exist
 
@@ -124,7 +124,7 @@ wmill gitsync-settings pull --diff --json-output
 # Replace top-level settings (non-interactive)
 wmill gitsync-settings pull --replace
 
-# Add branch-specific override (non-interactive)  
+# Add workspace-specific override (non-interactive)  
 wmill gitsync-settings pull --override
 
 # Write to defaults section

--- a/docs/advanced/3_cli/sync.mdx
+++ b/docs/advanced/3_cli/sync.mdx
@@ -9,7 +9,7 @@ import DocCard from '@site/src/components/DocCard';
 Synchronizing folders & git repositories to a Windmill instance is made easy
 using the wmill CLI. Syncing operations are behind the `wmill sync` subcommand.
 
-The CLI supports [environment-specific items](./environment-specific-items.mdx) that allow different versions of resources and variables per environment/branch.
+The CLI supports [workspace-specific items](./environment-specific-items.mdx) that allow different versions of resources and variables per workspace (dev / staging / prod).
 
 Having a Windmill instance synchronized to folders & git repositories allows for
 local development through the [VS Code extension](../../cli_local_dev/1_vscode-extension/index.mdx).
@@ -90,7 +90,7 @@ wmill sync pull [options]
 | `--yes`                | None          | Pull without needing confirmation. The command proceeds automatically without user intervention.                                                                                                                     |
 | `--plain-secrets`      | None          | Pull secrets as plain text. Secrets are downloaded without encryption or obfuscation.                                                                                                                                |
 | `--json`               | None          | Use JSON instead of YAML. The downloaded files are in JSON format instead of YAML.                                                                                                                                   |
-| `--workspace`          | `<workspace>` | Specify the target workspace. This overrides the default workspace.                                                                                                                                                  |
+| `--workspace`          | `<workspace>` | Select the target workspace. Matches a key in `workspaces:` (applying its `overrides` / `specificItems`) and falls back to a local profile name if no entry matches.                                                 |
 | `--debug`, `--verbose` | None          | Show debug/verbose logs.                                                                                                                                                                                             |
 | `--show-diffs`         | None          | Show diff information when syncing (may show sensitive information).                                                                                                                                                 |
 | `--token`              | `<token>`     | Specify an API token. This will override any stored token.                                                                                                                                                           |
@@ -105,8 +105,8 @@ wmill sync pull [options]
 | `--include-settings`   | None          | Include syncing workspace settings.                                                                                                                                                                                  |
 | `--include-key`        | None          | Include workspace encryption key.                                                                                                                                                                                    |
 | `--skip-branch-validation` | None      | Skip git branch validation and prompts. Useful for temporary feature branches that don't need to be added to wmill.yaml.                                                                                             |
-| `--branch`             | `<branch>`    | Override the current Git branch. Useful for working outside a Git repository or testing branch-specific configurations.                                                                                              |
-| `--env`                | `<env>`       | Override the environment name for single-branch setups. See [environment-specific items](./environment-specific-items.mdx).                                                                                                    |
+| `--branch`             | `<branch>`    | **Deprecated — use `--workspace` instead.** Overrides the detected git branch when resolving a `workspaces:` entry.                                                                                                  |
+| `--env`                | `<env>`       | **Deprecated — use `--workspace` instead.** Kept for single-branch setups that used the old `environments:` key.                                                                                                     |
 | `-i, --includes`       | `<patterns>`  | Comma-separated patterns to specify which files to take into account (among files compatible with Windmill). Overrides `wmill.yaml` includes. Patterns can include `*` (any string until '/') and `**` (any string). |
 | `-e, --excludes`       | `<patterns>`  | Comma-separated patterns to specify which files to NOT take into account. Overrides `wmill.yaml` excludes.                                                                                                           |
 | `--extra-includes`     | `<patterns>`  | Comma-separated patterns to specify which files to take into account (among files compatible with Windmill). Useful to still take `wmill.yaml` into account and act as a second pattern to satisfy.                  |
@@ -142,8 +142,8 @@ wmill sync push [options]
 | `--include-settings`   | None          | Include syncing workspace settings.                                                                                                                                                                 |
 | `--include-key`        | None          | Include workspace encryption key.                                                                                                                                                                   |
 | `--skip-branch-validation` | None      | Skip git branch validation and prompts. Useful for temporary feature branches that don't need to be added to wmill.yaml.                                                                            |
-| `--branch`             | `<branch>`    | Override the current Git branch. Useful for working outside a Git repository or testing branch-specific configurations.                                                                             |
-| `--env`                | `<env>`       | Override the environment name for single-branch setups. See [environment-specific items](./environment-specific-items.mdx).                                                                                   |
+| `--branch`             | `<branch>`    | **Deprecated — use `--workspace` instead.** Overrides the detected git branch when resolving a `workspaces:` entry.                                                                                 |
+| `--env`                | `<env>`       | **Deprecated — use `--workspace` instead.** Kept for single-branch setups that used the old `environments:` key.                                                                                    |
 | `-i, --includes`       | `<patterns>`  | Comma-separated patterns to specify which files to take into account (among files compatible with Windmill). Patterns can include `*` (any string until '/') and `**` (any string).                 |
 | `-e, --excludes`       | `<patterns>`  | Comma-separated patterns to specify which files to NOT take into account.                                                                                                                           |
 | `--extra-includes`     | `<patterns>`  | Comma-separated patterns to specify which files to take into account (among files compatible with Windmill). Useful to still take `wmill.yaml` into account and act as a second pattern to satisfy. |
@@ -213,45 +213,37 @@ includeKey: false
 skipBranchValidation: false  # Skip validation for feature branches
 ```
 
-### Git branch-specific configuration
+### Workspaces
 
-The CLI supports branch-specific settings through the `gitBranches` configuration. For single-branch, multi-environment setups, you can use the `environments` key instead — it works the same way but with `--env` instead of `--branch`. See [environment-specific items](./environment-specific-items.mdx) for details.
+Multi-target setups live under a single `workspaces` key in `wmill.yaml`. Each entry maps a
+human-friendly workspace name to a Windmill instance, optional per-workspace sync overrides,
+and optional workspace-specific items.
 
 ```yaml
-gitBranches:
-  main:  # Branch name
-    baseUrl: 'http://localhost:8000/'  # Windmill instance URL
-    workspaceId: test  # Workspace ID
-    overrides: {}  # Override settings for this branch
-    promotionOverrides:  # Settings used when promoting TO this branch
+workspaces:
+  staging:
+    baseUrl: https://staging.windmill.dev
+    # workspaceId defaults to "staging" (the key)
+    # gitBranch defaults to "staging" (the key)
+    overrides:
+      includeSchedules: true
+
+  production:
+    baseUrl: https://app.windmill.dev
+    workspaceId: prod-ws      # explicit: differs from the key
+    gitBranch: main           # explicit: maps to git branch "main"
+    overrides:
+      skipSecrets: false
+    promotionOverrides:       # applied when pushing with --promotion
       skipApps: true
       skipFlows: true
-    specificItems:  # Branch-specific resources/variables
+    specificItems:            # workspace-specific items (see below)
       resources:
         - "u/alex/prod_*"
       variables:
         - "u/alex/env_*"
 
-  staging:
-    baseUrl: 'https://staging.windmill.dev/'
-    workspaceId: staging-workspace
-    overrides:
-      skipVariables: true
-      includeSettings: true
-    promotionOverrides:
-      skipSecrets: true
-
-  production:
-    baseUrl: 'https://app.windmill.dev/'
-    workspaceId: prod-workspace
-    overrides:
-      includeSettings: true
-      skipSecrets: false
-    promotionOverrides:
-      skipApps: true      # Don't sync apps during promotion
-      skipFlows: true     # Don't sync flows during promotion
-
-  # Common items that are branch-specific across all branches
+  # Items that are workspace-specific across ALL workspaces
   commonSpecificItems:
     resources:
       - "u/alex/config/**"
@@ -262,14 +254,89 @@ gitBranches:
     settings: true
 ```
 
+Key properties:
+
+- **Key = workspace name.** It's a human-friendly identifier, not the git branch.
+- **`workspaceId` defaults to the key** — only set it when the Windmill workspace id differs from the name.
+- **`gitBranch` defaults to the key** — only set it when the git branch name differs.
+- **`baseUrl`** points at the Windmill instance; the CLI resolves it to a local
+  [profile](./workspace-management.md) (baseUrl + workspaceId match), so the same
+  `wmill.yaml` works on any machine as long as a matching profile is logged in.
+- **`overrides`** override any top-level sync option when this workspace is the current one.
+- **`promotionOverrides`** apply when pushing to this workspace with `--promotion`.
+- **`specificItems`** declare items that are stored per-workspace on disk (see
+  [workspace-specific items](./environment-specific-items.mdx)).
+
+### Selecting a workspace
+
+The CLI picks the active workspace in this order:
+
+1. `--workspace <name>` — explicit override, matches a key in `workspaces:` (or a local profile name as a fallback).
+2. **Current git branch** — the first entry whose effective `gitBranch` matches `git rev-parse --abbrev-ref HEAD`.
+3. **Local profile** — the active profile set via `wmill workspace switch` (used when no `workspaces:` entry matches).
+
+All sync commands (`wmill sync pull`, `wmill sync push`, `wmill gitsync-settings`, etc.)
+accept `--workspace` and apply the matching workspace's `overrides` / `specificItems`.
+
+### Binding a workspace to wmill.yaml
+
+`wmill workspace bind` interactively creates or updates a `workspaces:` entry from the active
+local profile. It prompts for the workspace name, git branch (optional), and handles the
+`workspaceId` / `baseUrl` fields for you.
+
+```bash
+wmill workspace bind                       # interactive: pick profile, name, branch
+wmill workspace bind --workspace staging   # non-interactive: use "staging" as the key
+wmill workspace unbind --workspace staging # remove baseUrl/workspaceId from the entry
+```
+
+`wmill init` also runs the bind flow automatically for fresh projects.
+
 ### Configuration resolution priority
 
 Settings are resolved in this order (highest priority first):
 
 1. **CLI flags** (highest priority)
 2. **Promotion overrides** (if `--promotion` flag is used)
-3. **Branch-specific overrides** (if current branch has `overrides` defined)
+3. **Workspace overrides** (from the resolved workspace's `overrides` block)
 4. **Top-level settings** (base configuration)
+
+### Migrating from `gitBranches` / `environments`
+
+Before this change, the CLI had three separate keys — `gitBranches`, `environments`, and
+`git_branches` — with the branch name as the map key and `workspaceId` always required.
+Unifying everything under `workspaces:` removes that duplication: one key, one flag
+(`--workspace`), and sensible defaults so most entries drop to two lines.
+
+Legacy configs keep working. On the first read of a legacy `wmill.yaml`, the CLI normalizes
+it to `workspaces:` in memory and prints a one-time deprecation warning. `--branch` and
+`--env` on sync commands are still accepted with a deprecation warning — prefer `--workspace`.
+
+To migrate the file on disk in one command:
+
+```bash
+wmill config migrate
+# ✅ Migrated 'gitBranches' to 'workspaces' in wmill.yaml
+#    Workspace entries: main, staging
+```
+
+The migration preserves every field — `baseUrl`, `workspaceId`, `overrides`,
+`promotionOverrides`, `specificItems`, `commonSpecificItems`. Since legacy keys were branch
+names, the resulting workspace name equals the old branch name and `gitBranch` is left
+implicit (it defaults to the key). [Workspace-specific item files](./environment-specific-items.mdx)
+keep the same suffix — the file `database.main.resource.yaml` stays valid because the
+workspace is still named `main`.
+
+### Inspecting the config
+
+`wmill config` prints a structured reference of every option with its default, type, and
+description. Pair with `--json` for machine-readable output.
+
+```bash
+wmill config            # human-readable reference
+wmill config --json     # JSON reference, one entry per option
+wmill config migrate    # legacy → workspaces
+```
 
 ### Codebase configuration
 
@@ -290,7 +357,7 @@ codebases:
     inject: ['./polyfills.js']
 ```
 
-All sync options for your workspace can be found on this [file](https://github.com/windmill-labs/windmill/blob/main/cli/src/core/conf.ts#L16):
+All sync options for your workspace can be found on this [file](https://github.com/windmill-labs/windmill/blob/main/cli/src/core/conf.ts):
 
 ```ts
 export interface SyncOptions {
@@ -328,8 +395,8 @@ export interface SyncOptions {
   defaultTs?: 'bun' | 'deno';
   codebases?: Codebase[];
 
-  // Git branch configuration
-  gitBranches?: {
+  // Workspace bindings — the single unified config key
+  workspaces?: {
     commonSpecificItems?: {
       variables?: string[];
       resources?: string[];
@@ -337,11 +404,13 @@ export interface SyncOptions {
       folders?: string[];
       settings?: boolean;
     };
-    [branchName: string]: SyncOptions & {
+    [workspaceName: string]: SyncOptions & {
+      // Defaults to the key (workspace name) when omitted
+      gitBranch?: string;
+      workspaceId?: string;
+      baseUrl?: string;
       overrides?: Partial<SyncOptions>;
       promotionOverrides?: Partial<SyncOptions>;
-      baseUrl?: string;
-      workspaceId?: string;
       specificItems?: {
         variables?: string[];
         resources?: string[];
@@ -349,8 +418,14 @@ export interface SyncOptions {
         folders?: string[];
         settings?: boolean;
       };
-    }
+    };
   };
+
+  // Deprecated — still read, normalized to `workspaces` in memory
+  gitBranches?: unknown;
+  environments?: unknown;
+  git_branches?: unknown;
+
   promotion?: string;
 }
 ```


### PR DESCRIPTION
## Summary

Documents the CLI change in [windmill#8767](https://github.com/windmill-labs/windmill/pull/8767) that unifies `gitBranches` / `environments` / `git_branches` into a single `workspaces:` key in `wmill.yaml`.

- New `### Workspaces` section in `docs/advanced/3_cli/sync.mdx` that explains the unified schema (key = human-friendly name, `workspaceId` / `gitBranch` default to the key), the `--workspace` resolution flow, `wmill workspace bind/unbind`, and the `wmill config migrate` one-shot migration.
- Full rewrite of `docs/advanced/3_cli/environment-specific-items.mdx` from an environments/branches framing to a workspace-centric framing (file suffix = workspace name, same transform logic). The page URL stays the same so external links keep working.
- Updates to `--workspace` / `--branch` / `--env` descriptions in the sync and gitsync-settings option tables — `--branch` and `--env` are marked deprecated; `--workspace` describes the new config lookup.
- Replaces the stale `SyncOptions` TypeScript snippet with the new `workspaces` shape.
- Cleans up stale `gitBranches` / "branch-specific" / "environment-specific" wording in `docs/advanced/11_git_sync`, `20_workspace_forks`, and `23_canonical_deployment_setups`.
- New changelog entry `changelog/2026-04-10-cli-workspaces-unification`.

The doc emphasizes that:
- Legacy configs keep working — normalized to `workspaces` in memory with a one-time deprecation warning.
- `wmill config migrate` converts on disk in one command; migrated workspace names equal the old branch names, so existing `*.branch.resource.yaml` files keep working unchanged.
- `wmill sync pull/push`, `wmill gitsync-settings`, and `wmill workspace fork/bind` all go through the same `--workspace` resolution.

## Test plan
- [x] `npm run build` passes (broken anchors reported are all pre-existing on unrelated pages)
- [ ] Manual review of the new sync.mdx `Workspaces` / `Migrating from gitBranches / environments` sections
- [ ] Manual review of the rewritten `environment-specific-items.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)