### PR TITLE
docs: bump windmill-cli to 1.682.0 in git sync

### DIFF
--- a/docs/advanced/11_git_sync/index.mdx
+++ b/docs/advanced/11_git_sync/index.mdx
@@ -244,7 +244,7 @@ jobs:
       - name: Push changes
         if: steps.check_message.outputs.skip != 'skip'
         run: |
-          npm install -g windmill-cli@1.393.3
+          npm install -g windmill-cli@1.682.0
           wmill sync push --yes --skip-variables --skip-secrets --skip-resources --workspace ${{ env.WMILL_WORKSPACE }} --token ${{ secrets.WMILL_TOKEN }} --base-url ${{ env.WMILL_URL }}
 ````
 
@@ -295,7 +295,7 @@ uses: actions/checkout@v3
       - name: Push changes
         if: steps.check_message.outputs.skip != 'skip'
         run: |
-          npm install -g windmill-cli@1.393.3
+          npm install -g windmill-cli@1.682.0
           wmill sync push --yes --skip-variables --skip-secrets --skip-resources --workspace ${{ steps.workspace.outputs.workspace }} --token ${{ secrets.WMILL_TOKEN }} --base-url ${{ env.WMILL_URL }}
 
 ````


### PR DESCRIPTION
## Summary
- Update windmill-cli version from 1.393.3 to 1.682.0 in git sync GitHub Actions examples

## Test plan
- [ ] Verify page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)