### PR TITLE
docs: git sync mono-branch resolution after force_branch removal

### DIFF
--- a/docs/advanced/3_cli/environment-specific-items.mdx
+++ b/docs/advanced/3_cli/environment-specific-items.mdx
@@ -284,20 +284,24 @@ Prefer simple workspace keys (`dev`, `staging`, `prod`) to avoid collisions.
 ## Git sync integration
 
 When [Git sync](../11_git_sync/index.mdx) is configured, workspace-specific items work
-seamlessly with your Git repository setup. Git sync pushes changes to the correct
-workspace-specific files based on the resolved workspace.
+seamlessly with your Git repository setup. On each Windmill-triggered sync, the backend
+invokes the CLI with `--base-url` and `--workspace` set to the current instance and
+workspace id. The CLI matches these against the `workspaces:` entries in `wmill.yaml`
+(on `baseUrl` + `workspaceId`) and applies the corresponding entry — no extra configuration
+on the Windmill side.
 
 - **One git branch per workspace**: each Windmill workspace's `git_repository` resource
-  points to a different branch. Git sync detects the branch and applies the matching
-  `workspaces:` entry automatically.
+  points to a different branch, and the `wmill.yaml` entry for that workspace sets
+  `gitBranch` accordingly.
   - **Production workspace**: `git_repository` pointing to `repoX` on `main` branch
     - Changes to `database.resource.yaml` → pushed as `database.prod.resource.yaml`
   - **Development workspace**: `git_repository` pointing to `repoX` on `dev` branch
     - Changes to `database.resource.yaml` → pushed as `database.dev.resource.yaml`
 
-- **Multiple workspaces on one git branch**: all Windmill workspaces point to the same
-  branch. Set the workspace name in the Git sync advanced settings so Git sync applies the
-  matching `workspaces:` entry.
+- **Multiple workspaces on one git branch** (mono-branch): all Windmill workspaces point to
+  the same branch. List each workspace under `workspaces:` with a distinct `workspaceId`
+  (and the same `gitBranch`); the CLI selects the right entry from the `--workspace` flag
+  the backend passes, so no UI toggle is needed.
 
 ## Related documentation
 


### PR DESCRIPTION
## Summary

- The `force_branch` toggle was removed from the Git sync UI in windmill [#8794](https://github.com/windmill-labs/windmill/pull/8794). This update rewrites the "Git sync integration" section of `environment-specific-items.mdx` to reflect the new resolution mechanism.
- Windmill-triggered syncs now pass `--base-url` and `--workspace` to the CLI; the CLI matches those against `baseUrl` + `workspaceId` in `wmill.yaml`'s `workspaces:` entries. Mono-branch setups just need distinct `workspaceId`s on the same `gitBranch`, no UI toggle required.

## Test plan

- [x] `npm run build` succeeds (pre-existing anchor warnings unrelated to this change)
- [ ] Spot-check rendered page at `/docs/advanced/cli/environment-specific-items#git-sync-integration`