### PR TITLE
docs: add CLI alternative for Slack connection

### DIFF
--- a/docs/advanced/3_cli/sync.mdx
+++ b/docs/advanced/3_cli/sync.mdx
@@ -463,3 +463,16 @@ To push to an instance use `wmill instance push`. It takes the same options as p
 When using `--include-workspaces`, you will also have to select the instance prefix of the local workspaces you want to push (make sure you're in its parent folder).
 
 During the push process, you will be prompted to decide whether to [re-encrypt](./workspace-management.md#managing-encryption-keys) the secrets of the workspace on the remote instance. In the case of instance migration, it is recommended to select "no" as the secrets are already encrypted with the correct key.
+
+### Instance-level Slack
+
+The CLI also supports connecting Slack at the instance level (global bot token used for critical alerts) non-interactively:
+
+```bash
+wmill instance connect-slack \
+  --bot-token <xoxb-…> \
+  --team-id <T…> \
+  --team-name "<team name>"
+```
+
+Super-admin only. Writes the `global_settings.slack` row and the encrypted variable + resource at `f/slack_bot/global_bot_token` in the `admins` workspace — same artifacts the UI's "Connect instance to Slack" button produces. See the [Slack integration doc](../../integrations/slack.mdx#action-on-windmill-from-slack) for the full flow, including configuring the OAuth client (`client_id`/`client_secret`) via `wmill instance push`.

--- a/docs/advanced/3_cli/workspace-management.md
+++ b/docs/advanced/3_cli/workspace-management.md
@@ -152,6 +152,38 @@ The wmill workspace whoami command allows you to display the currently active us
 wmill workspace whoami
 ```
 
+## Slack integration
+
+### Connect
+
+Non-interactively connect Slack to the active workspace using a pre-minted bot token (`xoxb-…`) obtained at [api.slack.com/apps](https://api.slack.com/apps). Produces the same DB state as the UI OAuth flow: `workspace_settings` fields, `g/slack` group, `slack_bot` folder, and the encrypted bot token variable + resource at `f/slack_bot/bot_token`.
+
+```bash
+wmill workspace connect-slack \
+  --bot-token <xoxb-…> \
+  --team-id <T…> \
+  --team-name "<team name>"
+```
+
+Admin-only. Idempotent: re-running with the same arguments is a no-op; a different `team-id` rewrites the binding in place.
+
+To get the `team-id` and `team-name` from the token, call Slack's `auth.test`:
+
+```bash
+curl -s -X POST https://slack.com/api/auth.test \
+  -H "Authorization: Bearer xoxb-YOUR-TOKEN"
+```
+
+For more context (scopes, instance-level counterpart, workspace-level OAuth override), see the [Slack integration doc](../../integrations/slack.mdx#action-on-windmill-from-slack).
+
+### Disconnect
+
+```bash
+wmill workspace disconnect-slack
+```
+
+Clears `slack_team_id` and `slack_name` on the active workspace. Does NOT remove the bot token variable/resource/folder/group — delete those from your local sync folder and run `wmill sync push` to tear them down. Does NOT remove the workspace-level OAuth override — set `slack_oauth_client_id` / `slack_oauth_client_secret` to `""` in `settings.yaml` and push.
+
 ## Managing encryption keys
 
 All [secrets](../../core_concepts/2_variables_and_secrets/index.mdx#secrets) of a workspace are [encrypted](../../core_concepts/30_workspace_secret_encryption/index.mdx) with a symmetric key unique to that workspace. This key is generated when the workspace is created and is stored in the database in the workspace_settings.

--- a/docs/integrations/slack.mdx
+++ b/docs/integrations/slack.mdx
@@ -32,8 +32,12 @@ The goal here is to be able to invoke a Windmill Script from Slack, by using
 
 <br />
 
-First, you need to be a **workspace admin**. Then you
-should go to
+First, you need to be a **workspace admin**. Then connect either through the UI or the [CLI](../advanced/3_cli/index.mdx):
+
+<Tabs className="unique-tabs">
+<TabItem value="ui" label="UI" default>
+
+Go to
 
 <a href="https://app.windmill.dev/workspace_settings" rel="nofollow">
 	Workspace Settings Page
@@ -70,6 +74,55 @@ are working on getting the app approved but you can safely ignore it for now.
 :::
 
 You can connect multiple Windmill workspaces to the same Slack workspace. Only one Windmill workspace can accept the `/windmill` [commands](#using-commands-on-slack) from a given Slack workspace. This feature is mostly useful for the [error handler](#error-handlers).
+
+</TabItem>
+<TabItem value="cli" label="CLI (non-interactive)">
+
+The CLI lets you connect Slack without going through the browser OAuth flow — useful for configure-as-code setups, CI provisioning, and scripted onboarding. It produces the same DB state as the UI flow (workspace_settings fields, `g/slack` group, `slack_bot` folder, encrypted `f/slack_bot/bot_token` variable and resource).
+
+First, create a Slack app at [api.slack.com/apps](https://api.slack.com/apps) (or use your existing one). In **OAuth & Permissions**, add the bot scopes Windmill expects (`commands`, `chat:write`, `chat:write.public`, `channels:join`, `files:write`, `app_mentions:read`, `im:history`, `im:read`), then click **Install to Workspace** to get the **Bot User OAuth Token** (`xoxb-…`).
+
+Fetch the `team_id` and `team_name` by calling `auth.test`:
+
+```bash
+curl -s -X POST https://slack.com/api/auth.test \
+  -H "Authorization: Bearer xoxb-YOUR-TOKEN"
+```
+
+Then connect the workspace:
+
+```bash
+wmill workspace connect-slack \
+  --bot-token xoxb-... \
+  --team-id T01234ABC \
+  --team-name "Your Team Name"
+```
+
+The command is admin-only and idempotent — re-running with the same arguments is a no-op, and running with a different team rewrites the binding in place. To disconnect later:
+
+```bash
+wmill workspace disconnect-slack
+```
+
+This clears `slack_team_id` and `slack_name`. To also remove the bot token variable/resource/folder/group, delete the corresponding files from your local sync folder and run `wmill sync push`.
+
+At the **instance level**, a super-admin can mint the global bot token (used for critical alerts) similarly:
+
+```bash
+wmill instance connect-slack \
+  --bot-token xoxb-... \
+  --team-id T01234ABC \
+  --team-name "Your Team Name"
+```
+
+:::info Before you can use `wmill {workspace,instance} connect-slack`
+
+The OAuth client (`client_id` / `client_secret`) still needs to exist in instance settings so fallback paths and the UI "Connect" button keep working. Configure it via the [instance settings UI](../advanced/18_instance_settings/index.mdx) or by editing `instance_settings.yaml`'s `oauths` entry and running `wmill instance push`.
+
+:::
+
+</TabItem>
+</Tabs>
 
 ### Using commands on Slack
 
@@ -274,9 +327,29 @@ By default, workspaces use the instance-level Slack app configured by your Windm
 
 To configure a workspace-specific Slack app:
 
+<Tabs className="unique-tabs">
+<TabItem value="ui" label="UI" default>
+
 1. Navigate to workspace settings → Slack app section
 2. Enter your Slack app's **Client ID** and **Client Secret**
 3. Save the configuration
+
+</TabItem>
+<TabItem value="cli" label="CLI (settings.yaml)">
+
+The workspace-level OAuth override lives in `settings.yaml` as two fields that round-trip via `wmill sync pull` / `wmill sync push`:
+
+```yaml
+slack_oauth_client_id: "1234567890.1234567890"
+slack_oauth_client_secret: "abcdef0123456789"
+```
+
+Set both to values and push to upsert; clear them (delete the lines or set both to `""`) and push to remove the workspace-level override and fall back to the instance-level Slack app. `wmill sync pull` always emits the two fields (`null` when unset), so round-trip is bijective — the committed YAML is a complete snapshot.
+
+After the override is in place, use the CLI's non-interactive connect command described above, or the UI's workspace-specific "Save and Connect" button (which authorizes using the workspace-level client).
+
+</TabItem>
+</Tabs>
 
 :::note
 The workspace-level Slack app will only apply to the auomatically managed `f/slack_bot/bot_token` resource used for workspace handlers and slack approvals. For general user specific slack oauth tokens, the instance level OAuth connection will be used.

--- a/docs/misc/2_setup_oauth/index.mdx
+++ b/docs/misc/2_setup_oauth/index.mdx
@@ -355,6 +355,12 @@ Now users should be able to connect to Slack through OAuth:
 
 ![Slack Connect](./slack_connect.png 'Slack Connect')
 
+:::tip Non-interactive CLI alternative
+
+The Slack bot install at the instance level (that normally happens when the first super-admin clicks "Connect to Slack") can also be done non-interactively via the CLI with a pre-minted `xoxb-…` bot token: `wmill instance connect-slack --bot-token ... --team-id ... --team-name ...`. Same for workspace-level: `wmill workspace connect-slack ...`. See the [Slack integration doc](../../integrations/slack.mdx#action-on-windmill-from-slack) for the full flow. Useful for configure-as-code setups and scripted provisioning.
+
+:::
+
 #### Workspace-level Slack app
 
 In addition to instance-level configuration, workspace admins can configure their own Slack app with workspace-specific credentials. This provides workspace isolation, separate rate limits, and independent management.
@@ -363,6 +369,8 @@ To enable workspace-level Slack apps:
 1. Follow the same app manifest setup above to create a Slack app
 2. In workspace settings, navigate to the Slack app section
 3. Enter the workspace-specific Client ID and Client Secret
+
+Alternatively, via the CLI, commit `slack_oauth_client_id` and `slack_oauth_client_secret` to your workspace's `settings.yaml` and run `wmill sync push`. Both fields round-trip through `sync pull` (emitted as `null` when unset), so the committed YAML is the complete source of truth.
 
 When configured, the workspace will use its own Slack app instead of the instance-level app. See the [Slack integration documentation](../../integrations/slack.mdx#workspace-level-slack-app-configuration) for more details on workspace-level configuration and when to use it.
 


### PR DESCRIPTION
Companion docs PR for:
- windmill-labs/windmill#8935
- windmill-labs/windmill-ee-private#550

## Summary

Adds CLI-based alternatives to the UI "Connect to Slack" flow in the main Slack integration doc, now shown in tabs alongside the UI instructions. Covers the new non-interactive commands:

- \`wmill workspace connect-slack\`
- \`wmill workspace disconnect-slack\`
- \`wmill instance connect-slack\`

using a pre-minted \`xoxb-\` bot token obtained at api.slack.com/apps.

## Changes

- \`docs/integrations/slack.mdx\`: wrapped the existing UI instructions in a UI/CLI Tabs block and added the CLI alternative (scopes, \`auth.test\` call to fetch team_id, \`connect-slack\` / \`disconnect-slack\` commands, and a caveat that the OAuth client still needs to be configured at the instance level for fallback paths).
- \`docs/integrations/slack.mdx\`: in the existing "Workspace-level Slack app configuration" section, added a CLI tab showing the \`slack_oauth_client_id\` / \`slack_oauth_client_secret\` fields in \`settings.yaml\` and the \`sync pull\`/\`sync push\` round-trip.
- \`docs/misc/2_setup_oauth/index.mdx\`: added a short pointer from the Slack OAuth setup section to the CLI install flow for configure-as-code / scripted provisioning.

## Test plan

- [ ] \`npm run build\` (Docusaurus) locally passes — MDX / Tabs syntax valid
- [ ] Spot-check rendered output on the preview deploy (tabs render, anchors work, \`#workspace-level-slack-app-configuration\` link still resolves)

---
Generated with [Claude Code](https://claude.com/claude-code)