### PR TITLE
docs: add Google ADK agent guide for AI sandbox

### DIFF
--- a/docs/core_concepts/58_ai_sandbox/index.mdx
+++ b/docs/core_concepts/58_ai_sandbox/index.mdx
@@ -250,4 +250,9 @@ A good rule of thumb: if the agent might run a shell command that needs a creden
   description="Sandbox annotation and nsjail"
   href="/docs/advanced/security_isolation"
 />
+  <DocCard
+    title="Build a Google ADK agent"
+    description="End-to-end Python example with persistent session memory"
+    href="/docs/misc/guides/adk_agent"
+  />
 </div>

--- a/docs/misc/9_guides/adk_agent/index.mdx
+++ b/docs/misc/9_guides/adk_agent/index.mdx
@@ -34,13 +34,14 @@ A weather assistant agent that:
 - Defines a single ADK agent with one function tool.
 - Runs inside an [nsjail](/docs/advanced/security_isolation#nsjail-sandboxing) sandbox so the agent process is isolated from the worker.
 - Persists session history to a SQLite database stored in a [volume](/docs/core_concepts/volumes), so subsequent runs resume where the conversation left off.
-- Takes a `prompt` and a Gemini API key as script inputs and returns the agent's final response.
+- Takes a `prompt` and a `googleai` [resource](/docs/core_concepts/resources_and_types) as script inputs and returns the agent's final response.
 
 ## Prerequisites
 
 - A Windmill instance with [workspace object storage](/docs/core_concepts/object_storage_in_windmill#workspace-object-storage) configured (required for volumes).
 - [Workers](/docs/core_concepts/worker_groups) with `nsjail` available (included in standard Windmill Docker images).
 - A Google AI Studio API key — get one at [aistudio.google.com/apikey](https://aistudio.google.com/apikey).
+- A `googleai` resource holding the API key. The `googleai` [resource type](https://hub.windmill.dev/resource_types/222/googleai) ships on the Windmill Hub; create a resource of that type and paste your key into `api_key`.
 
 ## Step 1: Create the script
 
@@ -55,16 +56,22 @@ Create a new script and paste the code for your language. The two annotations at
 
 #requirements:
 #google-adk
-#aiosqlite
 
 import asyncio
 import os
 from pathlib import Path
+from typing import TypedDict
 
 from google.adk.agents import Agent
 from google.adk.runners import Runner
-from google.adk.sessions import DatabaseSessionService
+from google.adk.sessions.sqlite_session_service import SqliteSessionService
 from google.genai import types
+
+
+class googleai(TypedDict):
+    api_key: str
+    base_url: str
+    platform: str
 
 
 def get_weather(city: str) -> dict:
@@ -107,10 +114,11 @@ DB_FILE = STATE_DIR / "sessions.db"
 async def _run(prompt: str) -> dict:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
 
-    # ADK uses SQLAlchemy's async engine, so the URL needs the aiosqlite driver.
-    session_service = DatabaseSessionService(
-        db_url=f"sqlite+aiosqlite:///{DB_FILE}"
-    )
+    # SQLite-native service (REAL-typed timestamps, plain aiosqlite). ADK's
+    # generic DatabaseSessionService is SQLAlchemy-based and aimed at
+    # postgres/mysql; on SQLite it can fail on resume with
+    # `fromisoformat: argument must be str`.
+    session_service = SqliteSessionService(str(DB_FILE))
 
     saved_id = SESSION_FILE.read_text().strip() if SESSION_FILE.exists() else None
     session = None
@@ -153,10 +161,14 @@ async def _run(prompt: str) -> dict:
     }
 
 
-def main(google_api_key: str, prompt: str = "What's the weather in Paris?") -> dict:
-    # ADK reads GOOGLE_API_KEY from the environment, so set it before running.
-    # Script inputs are not env vars — see "Passing credentials" below.
-    os.environ["GOOGLE_API_KEY"] = google_api_key
+def main(gemini: googleai, prompt: str = "What's the weather in Paris?") -> dict:
+    # Script inputs are not env vars — set them explicitly.
+    # See "Passing credentials" below.
+    os.environ["GOOGLE_API_KEY"] = gemini["api_key"]
+    if gemini.get("platform") == "google_vertex_ai":
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "true"
+    if gemini.get("base_url"):
+        os.environ["GOOGLE_GEMINI_BASE_URL"] = gemini["base_url"]
     return asyncio.run(_run(prompt))
 ```
 
@@ -209,13 +221,19 @@ const SESSION_FILE = path.join(STATE_DIR, 'session-id.txt')
 const DB_FILE = path.join(STATE_DIR, 'sessions.db')
 
 export async function main(
-  google_api_key: string,
+  gemini: RT.Googleai,
   prompt: string = "What's the weather in Paris?"
 ) {
   // adk-js reads GEMINI_API_KEY (or GOOGLE_GENAI_API_KEY) — script inputs
   // are not env vars, set them explicitly. See "Passing credentials" below.
-  process.env.GEMINI_API_KEY = google_api_key
-  process.env.GOOGLE_GENAI_API_KEY = google_api_key
+  process.env.GEMINI_API_KEY = gemini.api_key
+  process.env.GOOGLE_GENAI_API_KEY = gemini.api_key
+  if (gemini.platform === 'google_vertex_ai') {
+    process.env.GOOGLE_GENAI_USE_VERTEXAI = 'true'
+  }
+  if (gemini.base_url) {
+    process.env.GOOGLE_GEMINI_BASE_URL = gemini.base_url
+  }
 
   fs.mkdirSync(STATE_DIR, { recursive: true })
 
@@ -314,10 +332,10 @@ If you want a fresh conversation, delete the volume contents (or use a different
 
 ADK ships several [session services](https://google.github.io/adk-docs/sessions/session/). `InMemorySessionService` loses state at the end of each job — useless across Windmill runs. `DatabaseSessionService` with a SQLite URL inside the volume gives you persistence with zero infrastructure.
 
-The URL format differs slightly between languages:
+The two ports do not use the same SQLite implementation:
 
-- **Python** uses SQLAlchemy's async engine, so the URL needs the `aiosqlite` driver: `sqlite+aiosqlite:///<path>`. Add `aiosqlite` to your `#requirements:`.
-- **TypeScript** uses MikroORM's SQLite driver: `sqlite://<path>`. No extra dependency needed.
+- **Python** — use `SqliteSessionService` (in `google.adk.sessions.sqlite_session_service`). It's a SQLite-native service that stores timestamps as `REAL` and goes through `aiosqlite` directly, sidestepping a SQLAlchemy + aiosqlite type-marshalling bug that surfaces on resume as `fromisoformat: argument must be str`. The generic `DatabaseSessionService` is fine for postgres/mysql but should not be used with SQLite.
+- **TypeScript** — `DatabaseSessionService` works with a `sqlite://<path>` URL via MikroORM. No extra dependency needed.
 
 For multi-user or multi-tenant setups, scope the volume per workspace or input:
 
@@ -335,6 +353,11 @@ Script inputs are language variables — they are **not** automatically exported
 - **TypeScript** (`@google/adk`) reads `GEMINI_API_KEY` or `GOOGLE_GENAI_API_KEY`.
 
 Apply the same pattern for any other credential the agent or its tools need at runtime — for example `OPENAI_API_KEY`, `TAVILY_API_KEY`, or an MCP server token.
+
+The script also forwards the resource's optional `platform` and `base_url` fields:
+
+- `platform: "google_vertex_ai"` flips ADK to Vertex mode by setting `GOOGLE_GENAI_USE_VERTEXAI=true`. Vertex needs `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` set on the worker (or wired through additional script inputs).
+- `base_url` is exported as `GOOGLE_GEMINI_BASE_URL` for users running behind a proxy or against a non-default endpoint. Most users leave both fields empty.
 
 ## Extending the agent
 
@@ -400,7 +423,7 @@ Drop this script into any [flow](/docs/flows/flow_editor) step and chain it with
 
 - **`#sandbox` annotation but nsjail is not available** — your worker image does not include nsjail. Use a standard Windmill Docker image or remove the annotation.
 - **Volume not persisting** — check that workspace object storage is configured under [instance settings](/docs/advanced/instance_settings). Without it, volumes only exist for the duration of a single job.
-- **`Failed to create database engine for URL 'sqlite:///…'`** (Python) — ADK's `DatabaseSessionService` uses an async engine, so the URL needs the `aiosqlite` driver: `sqlite+aiosqlite:///<path>`. Make sure `aiosqlite` is listed under `#requirements:`.
+- **`fromisoformat: argument must be str`** (Python, on resume) — you used `DatabaseSessionService` against SQLite, which hits a SQLAlchemy + aiosqlite type-marshalling bug. Switch to `SqliteSessionService` from `google.adk.sessions.sqlite_session_service` (the snippet above already does this) and delete the old `.adk/sessions.db`.
 - **`API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY`** (TypeScript) — the JS port reads `GEMINI_API_KEY` / `GOOGLE_GENAI_API_KEY`, not `GOOGLE_API_KEY`. Set both for portability.
 
 <div className="grid grid-cols-2 gap-6 mb-4">

--- a/docs/misc/9_guides/adk_agent/index.mdx
+++ b/docs/misc/9_guides/adk_agent/index.mdx
@@ -1,0 +1,292 @@
+---
+title: Build a Google ADK agent in an AI sandbox
+description: How do I run a Google ADK agent on Windmill? Wrap it in an AI sandbox script with persistent session memory.
+---
+
+import DocCard from '@site/src/components/DocCard';
+
+# Build a Google ADK agent in an AI sandbox
+
+This guide walks you through running a [Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) agent on Windmill as a single Python [script](/docs/getting_started/scripts_quickstart). The agent runs inside an [AI sandbox](/docs/core_concepts/ai_sandbox), keeps its session state in a [volume](/docs/core_concepts/volumes), and exposes a clean `main()` entry point you can call from a [flow](/docs/flows/flow_editor), a [trigger](/docs/getting_started/triggers), or the UI.
+
+ADK is a code-first Python framework for building, evaluating, and orchestrating agents. It is optimized for [Gemini](https://aistudio.google.com/) but model-agnostic, so the same script works with other providers via [LiteLLM](https://google.github.io/adk-docs/agents/models/#non-google-models).
+
+<div className="grid grid-cols-2 gap-6 mb-4">
+	<DocCard
+		title="AI sandbox"
+		description="Run AI agents with process isolation and persistent volumes."
+		href="/docs/core_concepts/ai_sandbox"
+	/>
+	<DocCard
+		title="ADK documentation"
+		description="Google's Agent Development Kit reference and samples."
+		href="https://google.github.io/adk-docs/"
+		target="_blank"
+	/>
+</div>
+
+## What you'll build
+
+A weather assistant agent that:
+
+- Defines a single ADK `Agent` with one Python function tool.
+- Runs inside an [nsjail](/docs/advanced/security_isolation#nsjail-sandboxing) sandbox so the agent process is isolated from the worker.
+- Persists session history to a SQLite database stored in a [volume](/docs/core_concepts/volumes), so subsequent runs resume where the conversation left off.
+- Takes a `prompt` and a `google_api_key` as script inputs and returns the agent's final response.
+
+## Prerequisites
+
+- A Windmill instance with [workspace object storage](/docs/core_concepts/object_storage_in_windmill#workspace-object-storage) configured (required for volumes).
+- [Workers](/docs/core_concepts/worker_groups) with `nsjail` available (included in standard Windmill Docker images).
+- A Google AI Studio API key — get one at [aistudio.google.com/apikey](https://aistudio.google.com/apikey).
+
+## Step 1: Create the script
+
+Create a new Python script and paste the code below. The two annotations at the top are the only Windmill-specific parts — everything else is plain ADK.
+
+```python
+# sandbox
+# volume: adk-state .adk
+
+#requirements:
+#google-adk
+
+import asyncio
+import os
+from pathlib import Path
+
+from google.adk.agents import Agent
+from google.adk.runners import Runner
+from google.adk.sessions import DatabaseSessionService
+from google.genai import types
+
+
+def get_weather(city: str) -> dict:
+    """Return the current weather for a given city.
+
+    Args:
+        city: The city name to look up.
+    """
+    data = {
+        "paris": {"temp_c": 18, "conditions": "Sunny"},
+        "tokyo": {"temp_c": 22, "conditions": "Cloudy"},
+        "new york": {"temp_c": 12, "conditions": "Rainy"},
+    }
+    info = data.get(city.lower())
+    if info is None:
+        return {"status": "error", "message": f"No weather data for {city}."}
+    return {"status": "success", "city": city, **info}
+
+
+root_agent = Agent(
+    name="weather_agent",
+    model="gemini-2.5-flash",
+    description="Assistant that answers questions about the current weather.",
+    instruction=(
+        "You are a friendly weather assistant. "
+        "Call the get_weather tool when the user asks about weather. "
+        "If a city is not supported, suggest one of: Paris, Tokyo, New York."
+    ),
+    tools=[get_weather],
+)
+
+
+APP_NAME = "windmill_adk_demo"
+USER_ID = "windmill_user"
+STATE_DIR = Path(".adk")
+SESSION_FILE = STATE_DIR / "session-id.txt"
+DB_FILE = STATE_DIR / "sessions.db"
+
+
+async def _run(prompt: str) -> dict:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    session_service = DatabaseSessionService(db_url=f"sqlite:///{DB_FILE}")
+
+    saved_id = SESSION_FILE.read_text().strip() if SESSION_FILE.exists() else None
+    session = None
+    if saved_id:
+        session = await session_service.get_session(
+            app_name=APP_NAME, user_id=USER_ID, session_id=saved_id
+        )
+
+    is_resume = session is not None
+    if not is_resume:
+        session = await session_service.create_session(
+            app_name=APP_NAME, user_id=USER_ID
+        )
+        SESSION_FILE.write_text(session.id)
+
+    runner = Runner(
+        agent=root_agent,
+        app_name=APP_NAME,
+        session_service=session_service,
+    )
+
+    new_message = types.Content(
+        role="user", parts=[types.Part.from_text(text=prompt)]
+    )
+
+    response = ""
+    async for event in runner.run_async(
+        user_id=USER_ID, session_id=session.id, new_message=new_message
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    response += part.text
+
+    return {
+        "is_resume": is_resume,
+        "session_id": session.id,
+        "prompt": prompt,
+        "response": response,
+    }
+
+
+def main(google_api_key: str, prompt: str = "What's the weather in Paris?") -> dict:
+    # ADK reads GOOGLE_API_KEY from the environment, so set it before running.
+    # Script inputs are not env vars — see "Passing credentials" below.
+    os.environ["GOOGLE_API_KEY"] = google_api_key
+    return asyncio.run(_run(prompt))
+```
+
+## Step 2: Run it
+
+Click **Test** with a prompt like `"What's the weather in Paris?"` and your API key. You should see something like:
+
+```json
+{
+  "is_resume": false,
+  "session_id": "f7b2c1...",
+  "prompt": "What's the weather in Paris?",
+  "response": "It's sunny in Paris with a temperature of 18°C."
+}
+```
+
+Now run it again with `"And in Tokyo?"`. The script reads the saved session ID from the volume, resumes the same conversation, and the agent answers based on the prior turn:
+
+```json
+{
+  "is_resume": true,
+  "session_id": "f7b2c1...",
+  "prompt": "And in Tokyo?",
+  "response": "Tokyo is cloudy at 22°C."
+}
+```
+
+## How it works
+
+### `# sandbox`
+
+Wraps the job process in [nsjail](/docs/advanced/security_isolation#nsjail-sandboxing). The agent — and any subprocess it spawns (e.g. an MCP server or shell tool) — sees an isolated filesystem and cannot reach the worker's secrets or other jobs.
+
+### `# volume: adk-state .adk`
+
+Mounts a persistent volume at `./.adk` relative to the job's working directory. Files written there survive across runs and are synced to [object storage](/docs/core_concepts/object_storage_in_windmill). The script uses two files in the volume:
+
+- `.adk/session-id.txt` — the active ADK session ID, so the next run resumes the same conversation.
+- `.adk/sessions.db` — a SQLite database managed by ADK's `DatabaseSessionService`, holding the full session history.
+
+If you want a fresh conversation, delete the volume contents (or use a different volume name).
+
+### `DatabaseSessionService`
+
+ADK ships several [session services](https://google.github.io/adk-docs/sessions/session/). `InMemorySessionService` loses state at the end of each job — useless across Windmill runs. `DatabaseSessionService` with a SQLite URL inside the volume gives you persistence with zero infrastructure.
+
+For multi-user or multi-tenant setups, scope the volume per workspace or input:
+
+```python
+# volume: $workspace-adk-state .adk
+```
+
+See [dynamic volume names](/docs/core_concepts/volumes#dynamic-volume-names) for the full set of placeholders.
+
+### Passing credentials
+
+Script inputs are Python variables — they are **not** automatically exported as environment variables inside the sandbox. ADK (and the underlying `google-genai` client) reads `GOOGLE_API_KEY` from `os.environ`, so the script sets it explicitly:
+
+```python
+os.environ["GOOGLE_API_KEY"] = google_api_key
+```
+
+Apply the same pattern for any other credential the agent or its tools need at runtime — for example `OPENAI_API_KEY`, `TAVILY_API_KEY`, or an MCP server token.
+
+## Extending the agent
+
+### Use a different model
+
+ADK is model-agnostic via [LiteLLM](https://google.github.io/adk-docs/agents/models/#non-google-models). To run the same agent on Anthropic Claude, replace the `model=` line:
+
+```python
+from google.adk.models.lite_llm import LiteLlm
+
+root_agent = Agent(
+    name="weather_agent",
+    model=LiteLlm("anthropic/claude-3-5-sonnet-20241022"),
+    ...
+)
+```
+
+Then export `ANTHROPIC_API_KEY` (or the relevant provider key) the same way as `GOOGLE_API_KEY`. If you already have a Windmill `anthropic` [resource](/docs/core_concepts/resources_and_types), accept it as a script input:
+
+```python
+def main(anthropic: dict, prompt: str = "..."):
+    os.environ["ANTHROPIC_API_KEY"] = anthropic["apiKey"]
+    return asyncio.run(_run(prompt))
+```
+
+### Compose multiple agents
+
+ADK supports [multi-agent systems](https://google.github.io/adk-docs/agents/multi-agents/) out of the box — define sub-agents and assign them to a coordinator:
+
+```python
+greeter = Agent(name="greeter", model="gemini-2.5-flash", instruction="...", description="...")
+researcher = Agent(name="researcher", model="gemini-2.5-flash", instruction="...", description="...", tools=[...])
+
+root_agent = Agent(
+    name="coordinator",
+    model="gemini-2.5-flash",
+    description="Routes user requests to the right specialist.",
+    sub_agents=[greeter, researcher],
+)
+```
+
+The runner code stays unchanged — ADK handles the routing and tool calls.
+
+### Add MCP tools
+
+ADK can consume any [Model Context Protocol](https://modelcontextprotocol.io/) server via `MCPToolset`. Because the sandbox isolates subprocesses, you can safely launch MCP servers inside the same job:
+
+```python
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
+
+tools = await MCPToolset.from_server(
+    connection_params=StdioServerParameters(command="npx", args=["@modelcontextprotocol/server-filesystem", "."])
+)
+```
+
+Pair this with a separate volume for the MCP server's working directory if it needs persistent state.
+
+### Use the agent inside a flow
+
+Drop this script into any [flow](/docs/flows/flow_editor) step and chain it with other Windmill primitives — fetch context from a [database](/docs/integrations/postgresql), call the agent, then post the response to [Slack](/docs/integrations/slack). The volume keeps the agent's memory consistent across flow runs.
+
+## Troubleshooting
+
+- **`#sandbox` annotation but nsjail is not available** — your worker image does not include nsjail. Use a standard Windmill Docker image or remove the annotation.
+- **Volume not persisting** — check that workspace object storage is configured under [instance settings](/docs/advanced/instance_settings). Without it, volumes only exist for the duration of a single job.
+- **`GOOGLE_API_KEY not set`** — make sure you set `os.environ["GOOGLE_API_KEY"]` before calling `Runner.run_async`. Passing it to `Agent(...)` directly is not enough.
+
+<div className="grid grid-cols-2 gap-6 mb-4">
+	<DocCard
+		title="AI sandbox"
+		description="Run AI agents with process isolation and persistent volumes."
+		href="/docs/core_concepts/ai_sandbox"
+	/>
+	<DocCard
+		title="Volumes"
+		description="Persistent file storage for scripts, synced to object storage."
+		href="/docs/core_concepts/volumes"
+	/>
+</div>

--- a/docs/misc/9_guides/adk_agent/index.mdx
+++ b/docs/misc/9_guides/adk_agent/index.mdx
@@ -1,15 +1,17 @@
 ---
 title: Build a Google ADK agent in an AI sandbox
-description: How do I run a Google ADK agent on Windmill? Wrap it in an AI sandbox script with persistent session memory.
+description: How do I run a Google ADK agent on Windmill? Wrap it in an AI sandbox script (Python or TypeScript) with persistent session memory.
 ---
 
 import DocCard from '@site/src/components/DocCard';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Build a Google ADK agent in an AI sandbox
 
-This guide walks you through running a [Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) agent on Windmill as a single Python [script](/docs/getting_started/scripts_quickstart). The agent runs inside an [AI sandbox](/docs/core_concepts/ai_sandbox), keeps its session state in a [volume](/docs/core_concepts/volumes), and exposes a clean `main()` entry point you can call from a [flow](/docs/flows/flow_editor), a [trigger](/docs/getting_started/triggers), or the UI.
+This guide walks you through running a [Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) agent on Windmill as a single script. The agent runs inside an [AI sandbox](/docs/core_concepts/ai_sandbox), keeps its session state in a [volume](/docs/core_concepts/volumes), and exposes a clean `main()` entry point you can call from a [flow](/docs/flows/flow_editor), a [trigger](/docs/getting_started/triggers), or the UI.
 
-ADK is a code-first Python framework for building, evaluating, and orchestrating agents. It is optimized for [Gemini](https://aistudio.google.com/) but model-agnostic, so the same script works with other providers via [LiteLLM](https://google.github.io/adk-docs/agents/models/#non-google-models).
+ADK is a code-first framework for building, evaluating, and orchestrating agents. It is optimized for [Gemini](https://aistudio.google.com/) but model-agnostic, so the same script works with other providers via [LiteLLM](https://google.github.io/adk-docs/agents/models/#non-google-models). The same patterns shown here work with both the Python ([`google-adk`](https://pypi.org/project/google-adk/)) and the TypeScript ([`@google/adk`](https://www.npmjs.com/package/@google/adk)) ports.
 
 <div className="grid grid-cols-2 gap-6 mb-4">
 	<DocCard
@@ -29,10 +31,10 @@ ADK is a code-first Python framework for building, evaluating, and orchestrating
 
 A weather assistant agent that:
 
-- Defines a single ADK `Agent` with one Python function tool.
+- Defines a single ADK agent with one function tool.
 - Runs inside an [nsjail](/docs/advanced/security_isolation#nsjail-sandboxing) sandbox so the agent process is isolated from the worker.
 - Persists session history to a SQLite database stored in a [volume](/docs/core_concepts/volumes), so subsequent runs resume where the conversation left off.
-- Takes a `prompt` and a `google_api_key` as script inputs and returns the agent's final response.
+- Takes a `prompt` and a Gemini API key as script inputs and returns the agent's final response.
 
 ## Prerequisites
 
@@ -42,7 +44,10 @@ A weather assistant agent that:
 
 ## Step 1: Create the script
 
-Create a new Python script and paste the code below. The two annotations at the top are the only Windmill-specific parts — everything else is plain ADK.
+Create a new script and paste the code for your language. The two annotations at the top are the only Windmill-specific parts — everything else is plain ADK.
+
+<Tabs className="unique-tabs">
+<TabItem value="Python" label="Python" attributes={{className: "text-xs p-4 !mt-0 !ml-0"}}>
 
 ```python
 # sandbox
@@ -50,6 +55,7 @@ Create a new Python script and paste the code below. The two annotations at the 
 
 #requirements:
 #google-adk
+#aiosqlite
 
 import asyncio
 import os
@@ -101,7 +107,10 @@ DB_FILE = STATE_DIR / "sessions.db"
 async def _run(prompt: str) -> dict:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
 
-    session_service = DatabaseSessionService(db_url=f"sqlite:///{DB_FILE}")
+    # ADK uses SQLAlchemy's async engine, so the URL needs the aiosqlite driver.
+    session_service = DatabaseSessionService(
+        db_url=f"sqlite+aiosqlite:///{DB_FILE}"
+    )
 
     saved_id = SESSION_FILE.read_text().strip() if SESSION_FILE.exists() else None
     session = None
@@ -151,6 +160,117 @@ def main(google_api_key: str, prompt: str = "What's the weather in Paris?") -> d
     return asyncio.run(_run(prompt))
 ```
 
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript" attributes={{className: "text-xs p-4 !mt-0 !ml-0"}}>
+
+```typescript
+// sandbox
+// volume: adk-state .adk
+
+import { LlmAgent, FunctionTool, Runner, DatabaseSessionService } from '@google/adk'
+import { createUserContent } from '@google/genai'
+import { z } from 'zod'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+const getWeather = new FunctionTool({
+  name: 'get_weather',
+  description: 'Get the current weather for a city.',
+  parameters: z.object({
+    city: z.string().describe('The city name.'),
+  }),
+  execute: async ({ city }: { city: string }) => {
+    const data: Record<string, { temp_c: number; conditions: string }> = {
+      paris: { temp_c: 18, conditions: 'Sunny' },
+      tokyo: { temp_c: 22, conditions: 'Cloudy' },
+      'new york': { temp_c: 12, conditions: 'Rainy' },
+    }
+    const info = data[city.toLowerCase()]
+    if (!info) return { status: 'error', message: `No weather data for ${city}.` }
+    return { status: 'success', city, ...info }
+  },
+})
+
+const rootAgent = new LlmAgent({
+  name: 'weather_agent',
+  model: 'gemini-2.5-flash',
+  description: 'Assistant that answers questions about the current weather.',
+  instruction:
+    'You are a friendly weather assistant. ' +
+    'Call the get_weather tool when the user asks about weather. ' +
+    'If a city is not supported, suggest one of: Paris, Tokyo, New York.',
+  tools: [getWeather],
+})
+
+const APP_NAME = 'windmill_adk_demo'
+const USER_ID = 'windmill_user'
+const STATE_DIR = '.adk'
+const SESSION_FILE = path.join(STATE_DIR, 'session-id.txt')
+const DB_FILE = path.join(STATE_DIR, 'sessions.db')
+
+export async function main(
+  google_api_key: string,
+  prompt: string = "What's the weather in Paris?"
+) {
+  // adk-js reads GEMINI_API_KEY (or GOOGLE_GENAI_API_KEY) — script inputs
+  // are not env vars, set them explicitly. See "Passing credentials" below.
+  process.env.GEMINI_API_KEY = google_api_key
+  process.env.GOOGLE_GENAI_API_KEY = google_api_key
+
+  fs.mkdirSync(STATE_DIR, { recursive: true })
+
+  const sessionService = new DatabaseSessionService(`sqlite://${DB_FILE}`)
+
+  const savedId = fs.existsSync(SESSION_FILE)
+    ? fs.readFileSync(SESSION_FILE, 'utf-8').trim()
+    : undefined
+
+  let session = savedId
+    ? await sessionService.getSession({
+        appName: APP_NAME,
+        userId: USER_ID,
+        sessionId: savedId,
+      })
+    : undefined
+
+  const isResume = !!session
+  if (!session) {
+    session = await sessionService.createSession({
+      appName: APP_NAME,
+      userId: USER_ID,
+    })
+    fs.writeFileSync(SESSION_FILE, session.id)
+  }
+
+  const runner = new Runner({
+    appName: APP_NAME,
+    agent: rootAgent,
+    sessionService,
+  })
+
+  let response = ''
+  for await (const event of runner.runAsync({
+    userId: USER_ID,
+    sessionId: session.id,
+    newMessage: createUserContent(prompt),
+  })) {
+    for (const part of event.content?.parts ?? []) {
+      if (part.text) response += part.text
+    }
+  }
+
+  return {
+    is_resume: isResume,
+    session_id: session.id,
+    prompt,
+    response,
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
 ## Step 2: Run it
 
 Click **Test** with a prompt like `"What's the weather in Paris?"` and your API key. You should see something like:
@@ -158,9 +278,9 @@ Click **Test** with a prompt like `"What's the weather in Paris?"` and your API 
 ```json
 {
   "is_resume": false,
-  "session_id": "f7b2c1...",
+  "session_id": "51b81888-567e-4f46-9190-dff1e1c4eefd",
   "prompt": "What's the weather in Paris?",
-  "response": "It's sunny in Paris with a temperature of 18°C."
+  "response": "The weather in Paris is Sunny with a temperature of 18 degrees Celsius."
 }
 ```
 
@@ -169,7 +289,7 @@ Now run it again with `"And in Tokyo?"`. The script reads the saved session ID f
 ```json
 {
   "is_resume": true,
-  "session_id": "f7b2c1...",
+  "session_id": "51b81888-567e-4f46-9190-dff1e1c4eefd",
   "prompt": "And in Tokyo?",
   "response": "Tokyo is cloudy at 22°C."
 }
@@ -177,11 +297,11 @@ Now run it again with `"And in Tokyo?"`. The script reads the saved session ID f
 
 ## How it works
 
-### `# sandbox`
+### `# sandbox` / `// sandbox`
 
 Wraps the job process in [nsjail](/docs/advanced/security_isolation#nsjail-sandboxing). The agent — and any subprocess it spawns (e.g. an MCP server or shell tool) — sees an isolated filesystem and cannot reach the worker's secrets or other jobs.
 
-### `# volume: adk-state .adk`
+### `# volume: adk-state .adk` / `// volume: adk-state .adk`
 
 Mounts a persistent volume at `./.adk` relative to the job's working directory. Files written there survive across runs and are synced to [object storage](/docs/core_concepts/object_storage_in_windmill). The script uses two files in the volume:
 
@@ -194,21 +314,25 @@ If you want a fresh conversation, delete the volume contents (or use a different
 
 ADK ships several [session services](https://google.github.io/adk-docs/sessions/session/). `InMemorySessionService` loses state at the end of each job — useless across Windmill runs. `DatabaseSessionService` with a SQLite URL inside the volume gives you persistence with zero infrastructure.
 
+The URL format differs slightly between languages:
+
+- **Python** uses SQLAlchemy's async engine, so the URL needs the `aiosqlite` driver: `sqlite+aiosqlite:///<path>`. Add `aiosqlite` to your `#requirements:`.
+- **TypeScript** uses MikroORM's SQLite driver: `sqlite://<path>`. No extra dependency needed.
+
 For multi-user or multi-tenant setups, scope the volume per workspace or input:
 
-```python
-# volume: $workspace-adk-state .adk
+```
+// volume: $workspace-adk-state .adk
 ```
 
 See [dynamic volume names](/docs/core_concepts/volumes#dynamic-volume-names) for the full set of placeholders.
 
 ### Passing credentials
 
-Script inputs are Python variables — they are **not** automatically exported as environment variables inside the sandbox. ADK (and the underlying `google-genai` client) reads `GOOGLE_API_KEY` from `os.environ`, so the script sets it explicitly:
+Script inputs are language variables — they are **not** automatically exported as environment variables inside the sandbox. ADK reads its API key from the environment, so the scripts set it explicitly:
 
-```python
-os.environ["GOOGLE_API_KEY"] = google_api_key
-```
+- **Python** (`google-adk`) reads `GOOGLE_API_KEY`.
+- **TypeScript** (`@google/adk`) reads `GEMINI_API_KEY` or `GOOGLE_GENAI_API_KEY`.
 
 Apply the same pattern for any other credential the agent or its tools need at runtime — for example `OPENAI_API_KEY`, `TAVILY_API_KEY`, or an MCP server token.
 
@@ -216,7 +340,7 @@ Apply the same pattern for any other credential the agent or its tools need at r
 
 ### Use a different model
 
-ADK is model-agnostic via [LiteLLM](https://google.github.io/adk-docs/agents/models/#non-google-models). To run the same agent on Anthropic Claude, replace the `model=` line:
+ADK is model-agnostic. Both ports support [LiteLLM](https://google.github.io/adk-docs/agents/models/#non-google-models) (Python) or compatible model wrappers (TypeScript) to swap the underlying provider. To run the same agent on Anthropic Claude in Python, replace the `model=` line:
 
 ```python
 from google.adk.models.lite_llm import LiteLlm
@@ -276,7 +400,8 @@ Drop this script into any [flow](/docs/flows/flow_editor) step and chain it with
 
 - **`#sandbox` annotation but nsjail is not available** — your worker image does not include nsjail. Use a standard Windmill Docker image or remove the annotation.
 - **Volume not persisting** — check that workspace object storage is configured under [instance settings](/docs/advanced/instance_settings). Without it, volumes only exist for the duration of a single job.
-- **`GOOGLE_API_KEY not set`** — make sure you set `os.environ["GOOGLE_API_KEY"]` before calling `Runner.run_async`. Passing it to `Agent(...)` directly is not enough.
+- **`Failed to create database engine for URL 'sqlite:///…'`** (Python) — ADK's `DatabaseSessionService` uses an async engine, so the URL needs the `aiosqlite` driver: `sqlite+aiosqlite:///<path>`. Make sure `aiosqlite` is listed under `#requirements:`.
+- **`API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY`** (TypeScript) — the JS port reads `GEMINI_API_KEY` / `GOOGLE_GENAI_API_KEY`, not `GOOGLE_API_KEY`. Set both for portability.
 
 <div className="grid grid-cols-2 gap-6 mb-4">
 	<DocCard

--- a/sidebars.js
+++ b/sidebars.js
@@ -132,7 +132,8 @@ const sidebars = {
 								'misc/guides/otel/index',
 								'misc/guides/aws_marketplace/index',
 								'misc/guides/local_dev_with_ai/index',
-							'misc/guides/discord_bot/index'
+							'misc/guides/discord_bot/index',
+							'misc/guides/adk_agent/index'
 							]
 						}
 					]


### PR DESCRIPTION
## Summary

- New guide at `/docs/misc/guides/adk_agent` walks through running a [Google ADK](https://google.github.io/adk-docs/) agent end-to-end on Windmill, in **both Python and TypeScript**, as a single AI-sandbox script
- Pattern: `# sandbox` / `// sandbox` + `volume: adk-state .adk` + ADK's `DatabaseSessionService` pointed at a SQLite DB inside the volume — so each run resumes the prior conversation
- Tabs let the reader pick `google-adk` (Python) or `@google/adk` (TypeScript); the URL/driver differences (`sqlite+aiosqlite:///` vs `sqlite://`) and env-var quirks (`GOOGLE_API_KEY` vs `GEMINI_API_KEY`) are documented inline
- Extension paths covered: swap to Anthropic via LiteLlm, compose multi-agent systems, plug in MCP toolsets, drop the script into a flow
- AI sandbox index page gets a DocCard pointing to the new guide for discoverability; sidebar entry added next to the Discord bot guide

## Test plan

Both implementations were verified end-to-end inside Windmill against `gemini-2.5-flash`:

**Python** — prompt `"What's the weather in Paris?"`:
```json
{
  "is_resume": false,
  "session_id": "51b81888-567e-4f46-9190-dff1e1c4eefd",
  "prompt": "What's the weather in Paris?",
  "response": "The weather in Paris is Sunny with a temperature of 18 degrees Celsius."
}
```

**TypeScript** — same prompt:
```json
{
  "is_resume": false,
  "session_id": "44f8defa-98b3-4373-a465-6c3be2010dcb",
  "prompt": "What's the weather in Paris?",
  "response": "The weather in Paris is Sunny with a temperature of 18 degrees Celsius."
}
```

Both runs:
- Installed deps inside the worker (Python: 111 packages incl. `google-adk` + `aiosqlite`; TypeScript: 536 packages incl. `@google/adk` + `@google/genai` + `zod`)
- Confirmed `sandbox mode (nsjail)` in the logs
- Created the SQLite session DB and `session-id.txt` inside the mounted `.adk` volume
- Round-tripped through Gemini 2.5 Flash, with the agent invoking the `get_weather` tool

`npm run build` is clean for the new doc; the only remaining anchor warnings are pre-existing on unrelated pages.

## Known gap

Cross-run session resume requires workspace object storage to be configured (see prerequisites). The dev backend used here had no object storage backing, so within-run state worked but volume contents were not persisted between separate jobs — the doc calls this out under prerequisites and troubleshooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)