### PR TITLE
docs: S3Object input for native SQL scripts

### DIFF
--- a/changelog/2026-04-28-native-sql-s3-input/index.md
+++ b/changelog/2026-04-28-native-sql-s3-input/index.md
@@ -1,0 +1,22 @@
+---
+slug: native-sql-s3-input
+title: S3Object input for native SQL scripts
+tags: ['Script editor']
+description: Pass S3 objects as parameters to PostgreSQL, MSSQL, MySQL, BigQuery and Snowflake scripts and read them with the dialect's JSON-table function.
+features:
+  [
+    'Declare an `(s3object)` argument in any native SQL dialect; the worker downloads the file and binds it as a JSON parameter.',
+    'Auto-detects format from the object key extension: `.parquet`, `.csv`, `.json`/`.jsonl`.',
+    'Symmetric to the existing `-- s3` output flag — flow steps can hand S3 files between Bun-native and SQL steps without an intermediate client.',
+  ]
+docs: /docs/core_concepts/sql_to_s3_streaming#reading-s3-files-as-parameters
+---
+
+Native SQL scripts (PostgreSQL, MSSQL, MySQL, BigQuery, Snowflake) now accept `(s3object)` arguments. The worker downloads the file from workspace S3 storage, decodes it (Parquet and CSV via Apache Arrow; JSON/JSONL passed through), and binds it as a JSON parameter.
+
+```sql
+-- @P1 input_file (s3object)
+SELECT id, name FROM OPENJSON(@P1) WITH (id INT '$.id', name NVARCHAR(255) '$.name');
+```
+
+This is the symmetric path to the existing `-- s3` output flag: a Bun-native step can write its result to S3 and a follow-up SQL step can read it directly with the dialect's JSON-table function (`OPENJSON`, `jsonb_to_recordset`, `JSON_TABLE`, `JSON_QUERY_ARRAY`, `FLATTEN(input => PARSE_JSON(?))`), without a Python or Bun client step in between.

--- a/changelog/2026-04-28-native-sql-s3-input/index.md
+++ b/changelog/2026-04-28-native-sql-s3-input/index.md
@@ -7,7 +7,7 @@ features:
   [
     'Declare an `(s3object)` argument in any native SQL dialect; the worker downloads the file and binds it as a JSON parameter.',
     'Auto-detects format from the object key extension: `.parquet`, `.csv`, `.json`/`.jsonl`.',
-    'Symmetric to the existing `-- s3` output flag — flow steps can hand S3 files between Bun-native and SQL steps without an intermediate client.',
+    'Symmetric to the existing `-- s3` output flag: a previous flow step writes to S3, the next native SQL step reads it as a parameter.',
   ]
 docs: /docs/core_concepts/sql_to_s3_streaming#reading-s3-files-as-parameters
 ---
@@ -19,4 +19,4 @@ Native SQL scripts (PostgreSQL, MSSQL, MySQL, BigQuery, Snowflake) now accept `(
 SELECT id, name FROM OPENJSON(@P1) WITH (id INT '$.id', name NVARCHAR(255) '$.name');
 ```
 
-This is the symmetric path to the existing `-- s3` output flag: a Bun-native step can write its result to S3 and a follow-up SQL step can read it directly with the dialect's JSON-table function (`OPENJSON`, `jsonb_to_recordset`, `JSON_TABLE`, `JSON_QUERY_ARRAY`, `FLATTEN(input => PARSE_JSON(?))`), without a Python or Bun client step in between.
+This is the symmetric path to the existing `-- s3` output flag: a previous flow step writes a file to workspace S3 storage, and the next native SQL step picks it up by reference and reads it with the dialect's JSON-table function (`OPENJSON`, `jsonb_to_recordset`, `JSON_TABLE`, `JSON_QUERY_ARRAY`, `FLATTEN(input => PARSE_JSON(?))`).

--- a/changelog/2026-04-28-native-sql-s3-input/index.md
+++ b/changelog/2026-04-28-native-sql-s3-input/index.md
@@ -3,6 +3,7 @@ slug: native-sql-s3-input
 title: S3Object input for native SQL scripts
 tags: ['Script editor']
 description: Pass S3 objects as parameters to PostgreSQL, MSSQL, MySQL, BigQuery and Snowflake scripts and read them with the dialect's JSON-table function.
+version: v1.693.0
 features:
   [
     'Declare an `(s3object)` argument in any native SQL dialect; the worker downloads the file and binds it as a JSON parameter.',

--- a/docs/core_concepts/51_sql_to_s3_streaming/index.mdx
+++ b/docs/core_concepts/51_sql_to_s3_streaming/index.mdx
@@ -25,9 +25,7 @@ All `-- s3` parameters are optional:
 
 ## Reading S3 files as parameters
 
-Declare an `(s3object)` argument and the worker downloads the file, decodes it (auto-detected from the extension: `.json` / `.jsonl` / `.parquet` / `.csv`), and binds it as a JSON-text parameter. Your SQL then reads it with the dialect's JSON-table function.
-
-This is the symmetric path to `-- s3`: a flow step that writes its result to S3 (any language, including Bun-native scripts that bypass the internal Postgres) can be consumed by a follow-up native SQL step without an intermediate Python or Bun client.
+Declare an `(s3object)` argument and the worker downloads the file, decodes it (auto-detected from the extension: `.json` / `.jsonl` / `.parquet` / `.csv`), and binds it as a JSON-text parameter. Your SQL then reads it with the dialect's JSON-table function. This is the symmetric path to `-- s3`: a previous flow step (in any language) can write its result to S3 and the next native SQL step picks it up directly.
 
 | Dialect | Argument declaration | JSON-consumption pattern |
 |---|---|---|

--- a/docs/core_concepts/51_sql_to_s3_streaming/index.mdx
+++ b/docs/core_concepts/51_sql_to_s3_streaming/index.mdx
@@ -1,23 +1,56 @@
 ---
-description: How do I stream large SQL query results to S3 as CSV, JSON, or Parquet files in Windmill?
+description: How do I stream SQL query results to S3 and read S3 files as parameters from native SQL scripts in Windmill?
 ---
 
-# S3 streaming for large queries
+# Native SQL ↔ S3
 
-Sometimes, your SQL script will return too much data which exceeds the 10 000 rows query limit within Windmill. In this case, you
-will want to use the s3 flag to stream your query result to a file. You will need to have workspace storage enabled for this.
+Native SQL scripts (PostgreSQL, MSSQL, MySQL, BigQuery, Snowflake) can both stream their results to [workspace S3 storage](../38_object_storage_in_windmill/index.mdx) and consume S3 files as parameters. Both flows require workspace storage to be configured.
+
+## Streaming results to S3
+
+Use the `-- s3` flag when a query would otherwise blow past the 10 000 row in-memory limit:
 
 ```sql
 -- s3 prefix=datalake format=csv
 SELECT id, created_at FROM users
 ```
 
-This will return a path string to the generated file which has the job id as its name, for example in this case:
-`"datalake/0196c8e6-1fd4-0d05-d31c-c7eae9a12b1a.csv"`,
-which you can use in the next step of a flow to stream the file back from s3 and process it.
+This returns a path string to the generated file, named after the job id — for example `"datalake/0196c8e6-1fd4-0d05-d31c-c7eae9a12b1a.csv"`. A downstream flow step can pick it up by reference.
 
-All parameters are optional :
+All `-- s3` parameters are optional:
 
-- prefix : adds a prefix to the object key of the generated file. Default: wmill_datalake/path/to/job/id
-- format : json (default), csv or parquet
-- storage : name of the secondary workspace storage to use
+- `prefix`: object-key prefix for the generated file. Default: `wmill_datalake/path/to/job/id`
+- `format`: `json` (default), `csv`, or `parquet`
+- `storage`: name of the secondary workspace storage to use
+
+## Reading S3 files as parameters
+
+Declare an `(s3object)` argument and the worker downloads the file, decodes it (auto-detected from the extension: `.json` / `.jsonl` / `.parquet` / `.csv`), and binds it as a JSON-text parameter. Your SQL then reads it with the dialect's JSON-table function.
+
+This is the symmetric path to `-- s3`: a flow step that writes its result to S3 (any language, including Bun-native scripts that bypass the internal Postgres) can be consumed by a follow-up native SQL step without an intermediate Python or Bun client.
+
+| Dialect | Argument declaration | JSON-consumption pattern |
+|---|---|---|
+| PostgreSQL | `-- $1 input_file (s3object)` | `SELECT * FROM jsonb_to_recordset($1::jsonb) AS x(id INT, name TEXT);` |
+| MSSQL | `-- @P1 input_file (s3object)` | `SELECT * FROM OPENJSON(@P1) WITH (id INT '$.id', name NVARCHAR(255) '$.name');` |
+| MySQL | `-- :input_file (s3object)` | `SELECT * FROM JSON_TABLE(:input_file, '$[*]' COLUMNS (id INT PATH '$.id', name VARCHAR(255) PATH '$.name')) AS x;` |
+| BigQuery | `-- @input_file (s3object)` | `SELECT JSON_VALUE(row, '$.id') AS id, JSON_VALUE(row, '$.name') AS name FROM UNNEST(JSON_QUERY_ARRAY(@input_file)) AS row;` |
+| Snowflake | `-- ? input_file (s3object)` | `SELECT v.value:id::int AS id, v.value:name::string AS name FROM TABLE(FLATTEN(input => PARSE_JSON(?))) v;` |
+
+The `input_file` argument shows up in the run form as the standard S3 object picker.
+
+### Format detection
+
+The decoder picks a path from the object key's extension:
+
+- `.parquet` — decoded via Apache Arrow's Parquet reader and re-serialized to a JSON array.
+- `.csv` — decoded via Arrow's CSV reader (first row used as headers, types inferred).
+- `.json`, `.jsonl`, `.ndjson`, no extension — passed through; JSONL inputs are repackaged as a JSON array so the user SQL can uniformly assume an array shape.
+
+### Size limits
+
+The whole payload is bound as a single SQL parameter, so it sits in the worker's memory once and on the database driver's buffer once. The path is tested up to roughly 500 MB; beyond that you should keep the data in S3 and read it through the database engine's own loader (`COPY FROM`, `BULK INSERT`, BigQuery load job, Snowflake `PUT`/`COPY`, DuckDB `read_parquet('s3://...')`).
+
+### DuckDB
+
+DuckDB has its own `(s3object)` path: the engine reads from S3 directly, so the worker just substitutes a `s3://...` URI. See the [DuckDB section of the SQL quickstart](../../getting_started/0_scripts_quickstart/5_sql_quickstart/index.mdx#duckdb) for the read_parquet/read_csv/read_json patterns.

--- a/docs/getting_started/0_scripts_quickstart/5_sql_quickstart/index.mdx
+++ b/docs/getting_started/0_scripts_quickstart/5_sql_quickstart/index.mdx
@@ -564,6 +564,8 @@ You can then query this file using the standard read_csv/read_parquet/read_json 
 SELECT * FROM read_parquet($file)
 ```
 
+The other native SQL dialects (PostgreSQL, MSSQL, MySQL, BigQuery, Snowflake) also accept `(s3object)` arguments, but bind the file's contents as a JSON parameter that the user SQL reads with the dialect's JSON-table function (`OPENJSON`, `jsonb_to_recordset`, `JSON_TABLE`, ...). See [Native SQL ↔ S3](../../../core_concepts/51_sql_to_s3_streaming/index.mdx#reading-s3-files-as-parameters).
+
 Alternatively, you can reference files on the workspace directly using s3:// notation.
 
 For primary workspace storage:


### PR DESCRIPTION
## Summary

Documents the new `(s3object)` argument type for native SQL scripts (PG, MSSQL, MySQL, BigQuery, Snowflake), shipped in [windmill#8954](https://github.com/windmill-labs/windmill/pull/8954).

## Changes

- **`docs/core_concepts/51_sql_to_s3_streaming/index.mdx`** — broadened from output-only to bidirectional. Adds a "Reading S3 files as parameters" section with a per-dialect snippet table, format-detection rules, and a size-limit note that points to engine-native bulk loaders for >500 MB.
- **`docs/getting_started/0_scripts_quickstart/5_sql_quickstart/index.mdx`** — added a one-paragraph cross-reference under the existing DuckDB `(s3object)` section so readers landing in the quickstart find the per-dialect details.
- **`changelog/2026-04-28-native-sql-s3-input/index.md`** — new changelog entry, tagged `Script editor`, following the format of `2026-04-03-sql-raw`.

## Test plan

- [x] `npm run build` clean. The build's broken-anchor warnings are all pre-existing (db-health-dashboard, iam-rds-auth, workflows-as-code-v2, platform/script-editor) — none reference the new content.
- [x] Verified the cross-link target — `#reading-s3-files-as-parameters` — exists in the rendered HTML for `sql_to_s3_streaming`.
- [x] Both new pages built (`build/changelog/native-sql-s3-input.html`, `build/docs/core_concepts/sql_to_s3_streaming.html`).

---
Generated with [Claude Code](https://claude.com/claude-code)